### PR TITLE
Feat/add fix option and check changes

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -34,6 +34,8 @@ function writeGitHooksFiles() {
   });
 }
 
+const clear = () => process.stdout.write('\x1Bc');
+
 export function addInit(program: commander.Command): void {
   program
     .command('init')
@@ -66,6 +68,7 @@ export function addInit(program: commander.Command): void {
         transformer: (val: string) => `./${val}`,
       };
 
+      clear();
       const { packagesPath } = (await inquirer.prompt([folderQuestion])) as { packagesPath: string };
       const moduleDirs = fs
         .readdirSync(`./${packagesPath}`, { withFileTypes: true })
@@ -78,9 +81,11 @@ export function addInit(program: commander.Command): void {
           name: 'packages',
           message: 'Select folders to hook :',
           choices: moduleDirs,
+          pageSize: process.stdout.rows / 2,
         },
       ];
 
+      clear();
       const { packages } = (await inquirer.prompt(packagesQuestion)) as { packages: string[] };
       selectedPackages = selectedPackages.concat(packages);
 
@@ -129,6 +134,7 @@ export function addInit(program: commander.Command): void {
           },
         ];
 
+        clear();
         const { packages } = (await inquirer.prompt(packagesQuestion)) as { packages: string[] };
         selectedPackages = selectedPackages.concat(
           packages.map((subPackage) => `${packagesPath ? `${packagesPath}/` : ''}${subPath}/${subPackage}`),
@@ -159,6 +165,7 @@ export function addInit(program: commander.Command): void {
 
       const packagesHooksDirPaths = selectedPackages.map((mod) => `${mookMeConfig.packagesPath}/${mod}/.hooks`);
 
+      clear();
       console.log('\nThe following configuration will be added into your package.json:');
       console.log('mookme: ', JSON.stringify(mookMeConfig, null, 2));
 

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -1,4 +1,10 @@
+export enum ADDED_BEHAVIORS {
+  ADD_AND_COMMIT = 'addAndCommit',
+  EXIT = 'exit',
+}
+
 export interface Config {
   packagesPath: string;
   packages: string[];
+  addedBehavior: ADDED_BEHAVIORS;
 }


### PR DESCRIPTION
Add a feature for solving #1 

-> Provide a new configuration option `addedBehavior` to configure if we should add files and keep going, or just exit when files are modified by the invoked hooks.

In both cases, a warning is displayed: 

- 1. Add and continue
<img width="752" alt="image" src="https://user-images.githubusercontent.com/29194680/118190777-df792880-b443-11eb-967e-b3ec993844ae.png">

- 2. Exit
<img width="751" alt="image" src="https://user-images.githubusercontent.com/29194680/118190841-fd468d80-b443-11eb-8418-3345c08977d3.png">

Also add a related prompter for the initialization
<img width="586" alt="image" src="https://user-images.githubusercontent.com/29194680/118190943-20713d00-b444-11eb-8dc9-28e1930663a6.png">
