### PR TITLE
fix(run): fix package resolution

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,6 +8,7 @@ import { hookTypes, HookType, PackageHook } from '../types/hook.types';
 import { hookPackage } from '../utils/hook-package';
 import { getConfig } from '../utils/get-config';
 import { ADDED_BEHAVIORS } from '../types/config.types';
+import { getRootDir } from '../utils/get-root-dir';
 
 draftlog(console);
 
@@ -52,7 +53,10 @@ export function addRun(program: commander.Command): void {
         .split(' ')
         .map((file) => file.replace('\n', ''));
       const stagedFiles = execSync('echo $(git diff --cached --name-only)').toString().split(' ');
-      const packagesWithChanges = packages.filter((pkg) => stagedFiles.find((file) => file.includes(pkg)));
+      const rootDir = getRootDir();
+      const packagesWithChanges = packages.filter((pkg) =>
+        stagedFiles.find((file) => `${rootDir}/${file}`.includes(`${packagesPath}/${pkg}`)),
+      );
 
       const packagesToCheck = opts.runAll ? packages : packagesWithChanges;
 

--- a/src/utils/get-config.ts
+++ b/src/utils/get-config.ts
@@ -1,17 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import { Config } from '../types/config.types';
+import { getRootDir } from './get-root-dir';
 
 export function getConfig(): Config {
-  let isRoot = false;
-  let rootDir = process.cwd();
-  while (!isRoot) {
-    isRoot = fs.existsSync(`${rootDir}/.git`);
-    if (!isRoot) {
-      rootDir = `${rootDir}/..`;
-    }
-  }
-
+  const rootDir = getRootDir();
   const packageJSON = JSON.parse(fs.readFileSync(`${rootDir}/package.json`, 'utf8'));
   const config = packageJSON.mookme as Config;
 

--- a/src/utils/get-root-dir.ts
+++ b/src/utils/get-root-dir.ts
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import path from 'path';
+
+export function getRootDir(): string {
+  let isRoot = false;
+  let rootDir = process.cwd();
+  while (!isRoot) {
+    isRoot = fs.existsSync(`${rootDir}/.git`);
+    if (!isRoot) {
+      rootDir = `${rootDir}/..`;
+    }
+  }
+
+  return path.resolve(rootDir);
+}


### PR DESCRIPTION
This fixes the way modified packages are detected. Instead of looking for the package name, we use absolute path detection, in order to avoid misdetection and false positives.