### PR TITLE
Skip empty stages when running hooks

### DIFF
--- a/packages/mookme/src/commands/run.ts
+++ b/packages/mookme/src/commands/run.ts
@@ -38,10 +38,6 @@ export function addRun(program: commander.Command): void {
         process.exit(1);
       }
 
-      const title = ` Running commit hook ${type} `;
-      console.log();
-      center(title);
-
       const { packages, packagesPath, addedBehavior } = loadConfig();
       process.env.MOOKME_CONFIG = JSON.stringify({ packages, packagesPath, addedBehavior });
 
@@ -55,6 +51,14 @@ export function addRun(program: commander.Command): void {
       process.env.MOOKME_STAGED_FILES = JSON.stringify(stagedFiles.map((fPath) => path.join(rootDir, fPath)));
 
       const hooks = loadHooks(stagedFiles, type, { all: opts.all });
+
+      if (hooks.length === 0) {
+        return;
+      }
+
+      const title = ` Running commit hook ${type} `;
+      console.log();
+      center(title);
 
       // stashIfNeeded(type);
 


### PR DESCRIPTION
When using only pre-commit hooks, it looks a little funny to have the centered text as it starts all the other empty stages. This PR skips the printing (and checking of unstaged files) for any stages (ie. pre-commit, post-commit) that don't have any hooks.