### PR TITLE
Feat/serial usage

### DIFF
--- a/packages/docs/references/README.md
+++ b/packages/docs/references/README.md
@@ -87,6 +87,10 @@ The list of steps (commands) being executed by this hook. In a step you can defi
 | `name`      | The name that will be given to this step | yes |
 | `cmd`      | The command invoked at this step |   yes |
 | `onlyOn` | A shell wildcard conditioning the execution of the step based on modified files      |    no |
+| `serial` | A boolean value describing if the package hook execution should await for the step to end |    no |
+
+::: warning
+A serial step that fails will not prevent the execution of the following steps
 
 - `type`
 

--- a/packages/mookme/bin/index.js
+++ b/packages/mookme/bin/index.js
@@ -1,3 +1,5 @@
 #!/usr/bin/env node
-process.env.MOOKME_CLI_VERSION = require('../package.json').version
-require('../dist/index.js')
+process.env.MOOKME_CLI_VERSION = require('../package.json').version;
+// Utilitary line for usage in dev environment
+// console.log(`Running mookme from path : ${__filename}`);
+require('../dist/index.js');

--- a/packages/mookme/src/types/step.types.ts
+++ b/packages/mookme/src/types/step.types.ts
@@ -4,6 +4,7 @@ export interface StepCommand {
   name: string;
   command: string;
   onlyOn?: string;
+  serial?: boolean;
 }
 
 export interface StepError {

--- a/packages/mookme/src/utils/hook-package.ts
+++ b/packages/mookme/src/utils/hook-package.ts
@@ -3,16 +3,35 @@ import chalk from 'chalk';
 import { PackageHook } from '../types/hook.types';
 import { runStep } from './run-step';
 import { StepCommand, StepError } from '../types/step.types';
+import { loader } from './loader';
 
 draftlog(console);
 
-export function hookPackage(hook: PackageHook): Promise<{ hook: PackageHook; step: StepCommand; msg: Error }[]> {
-  const loggers: { [key: string]: (log: string) => void } = {};
+type Logger = (log: string) => void;
+interface UI {
+  packageLogger: Logger;
+  stepsLoggers: { [key: string]: { logger: Logger; interval: NodeJS.Timeout } };
+}
+
+function init_ui(hook: PackageHook): UI {
+  const ui: UI = {
+    packageLogger: console.draft(
+      `${chalk.bold.inverse(` Hooks : ${hook.name} `)}${chalk.bgBlueBright.bold(' Running... ')}`,
+    ),
+    stepsLoggers: {},
+  };
   console.log();
 
-  loggers[hook.name] = console.draft(
-    `${chalk.bold.inverse(` Hooks : ${hook.name} `)}${chalk.bgBlueBright.bold(' Running... ')}`,
-  );
+  for (const step of hook.steps) {
+    console.log(`→ ${chalk.bold(step.name)} > ${step.command} `);
+    ui.stepsLoggers[step.name] = loader();
+  }
+
+  return ui;
+}
+
+export async function hookPackage(hook: PackageHook): Promise<{ hook: PackageHook; step: StepCommand; msg: Error }[]> {
+  const ui: UI = init_ui(hook);
 
   const options = {
     name: hook.name,
@@ -21,29 +40,78 @@ export function hookPackage(hook: PackageHook): Promise<{ hook: PackageHook; ste
     venvActivate: hook.venvActivate,
   };
 
-  return new Promise((resolve, reject) =>
-    Promise.all(hook.steps.map((step) => runStep(step, options)))
-      .then((errors) => {
-        const hasError = errors.find((err) => err !== null);
-        const result = hasError ? chalk.bgRed.bold(' Error × ') : chalk.bgGreen.bold(' Done ✓ ');
-        loggers[hook.name](`${chalk.bold.inverse(` Hooks : ${hook.name} `)}${result}`);
-        resolve(
-          errors
-            .filter((err) => err !== null)
-            .map((err) => ({
+  const promises = [];
+  const errors: { hook: PackageHook; step: StepCommand; msg: Error }[] = [];
+
+  for (const step of hook.steps) {
+    try {
+      const { logger, interval } = ui.stepsLoggers[step.name];
+      const stepPromise = runStep(step, options, logger, interval);
+      promises.push(stepPromise);
+
+      if (step.serial) {
+        const stepError = await stepPromise;
+        let result: string = chalk.bgGreen.bold(' Done ✓ ');
+        if (stepError !== null) {
+          result = chalk.bgRed.bold(' Error × ');
+          errors.push({
+            hook,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            step: stepError!.step,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            msg: stepError!.msg,
+          });
+        }
+        ui.packageLogger(`${chalk.bold.inverse(` Hooks : ${hook.name} `)}${result}`);
+      } else {
+        stepPromise.then((stepError) => {
+          let result: string = chalk.bgGreen.bold(' Done ✓ ');
+          if (stepError !== null) {
+            result = chalk.bgRed.bold(' Error × ');
+            errors.push({
               hook,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              step: err!.step,
+              step: stepError!.step,
               // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-              msg: err!.msg,
-            })),
-        );
-      })
-      .catch((err) => {
-        loggers[hook.name](`${chalk.bold.inverse(` Hooks : ${hook.name} `)}${chalk.bgRed.bold(' Error × ')}`);
-        reject(err);
-      }),
-  );
+              msg: stepError!.msg,
+            });
+          }
+          ui.packageLogger(`${chalk.bold.inverse(` Hooks : ${hook.name} `)}${result}`);
+        });
+      }
+    } catch (err) {
+      ui.packageLogger(`${chalk.bold.inverse(` Hooks : ${hook.name} `)}${chalk.bgRed.bold(' Error × ')}`);
+      throw err;
+    }
+  }
+
+  await Promise.all(promises);
+
+  return errors;
+
+  // return await new Promise((resolve, reject) =>
+  //   Promise.all(hook.steps.map((step) => runStep(step, options)))
+  //     .then((errors) => {
+  //       const hasError = errors.find((err) => err !== null);
+  //       const result = hasError ? chalk.bgRed.bold(' Failed × ') : chalk.bgGreen.bold(' Success ✓ ');
+  //       loggers[hook.name](`${chalk.bold.inverse(` Hooks : ${hook.name} `)}${result}`);
+  //       resolve(
+  //         errors
+  //           .filter((err) => err !== null)
+  //           .map((err) => ({
+  //             hook,
+  //             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  //             step: err!.step,
+  //             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  //             msg: err!.msg,
+  //           })),
+  //       );
+  //     })
+  //     .catch((err) => {
+  //       loggers[hook.name](`${chalk.bold.inverse(` Hooks : ${hook.name} `)}${chalk.bgRed.bold(' Error × ')}`);
+  //       reject(err);
+  //     }),
+  // );
 }
 
 export function processResults(results: StepError[][]): void {

--- a/packages/mookme/src/utils/loader.ts
+++ b/packages/mookme/src/utils/loader.ts
@@ -1,22 +1,31 @@
-export function loader(initial = 'Running.. '): {
+export interface LoaderManager {
   logger: (log: string) => void;
+  updateMessage: (newMessage: string) => void;
   interval: ReturnType<typeof setInterval>;
-} {
-  let currentStatus = initial;
-  const logger = console.draft(currentStatus);
+}
+
+export function loader(initialMessage = 'Running'): LoaderManager {
+  let dotStatus = '.. ';
+  let message = initialMessage;
+  const logger = console.draft(message + dotStatus);
   const interval: ReturnType<typeof setInterval> = setInterval(() => {
-    switch (currentStatus) {
-      case 'Running.. ':
-        currentStatus = 'Running ..';
+    switch (dotStatus) {
+      case '.. ':
+        dotStatus = ' ..';
         break;
-      case 'Running ..':
-        currentStatus = 'Running. .';
+      case ' ..':
+        dotStatus = '. .';
         break;
-      case 'Running. .':
-        currentStatus = 'Running.. ';
+      case '. .':
+        dotStatus = '.. ';
         break;
     }
-    logger(currentStatus);
+    logger(message + dotStatus);
   }, 100);
-  return { logger, interval };
+
+  function updateMessage(newMessage: string): void {
+    message = newMessage;
+  }
+
+  return { logger, interval, updateMessage };
 }

--- a/packages/mookme/src/utils/run-step.ts
+++ b/packages/mookme/src/utils/run-step.ts
@@ -3,7 +3,6 @@ import chalk from 'chalk';
 import wcmatch from 'wildcard-match';
 import { exec } from 'child_process';
 import { StepCommand } from '../types/step.types';
-import { loader } from './loader';
 
 draftlog(console);
 
@@ -14,15 +13,16 @@ export interface RunStepOptions {
   venvActivate?: string;
 }
 
-export function runStep(step: StepCommand, options: RunStepOptions): Promise<{ step: StepCommand; msg: Error } | null> {
+export function runStep(
+  step: StepCommand,
+  options: RunStepOptions,
+  logger: (log: string) => void,
+  interval: NodeJS.Timeout,
+): Promise<{ step: StepCommand; msg: Error } | null> {
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const args = process.env.MOOKME_ARGS!.split(' ').filter((arg) => arg !== '');
 
   return new Promise((resolve) => {
-    console.log(`→ ${chalk.bold(step.name)} > ${step.command} `);
-
-    const { logger, interval } = loader();
-
     if (step.onlyOn) {
       try {
         const matcher = wcmatch(step.onlyOn);


### PR DESCRIPTION
This adds a new option in the step definition (as described in [issue 14](https://github.com/Escape-Technologies/mookme/issues/14) `serial`. IT behaves as follows : 

- When running mookme on a given package, we iterate over it's steps.
- For each steps, if it is a serial step, it is blocking, (the step promise is awaited) otherwise it only runs the step without awaiting the promise
- Every step promise is awaited before the end of the package execution