### PR TITLE
Feat/local steps

### DIFF
--- a/packages/docs/features/README.md
+++ b/packages/docs/features/README.md
@@ -87,3 +87,37 @@ One can declare a script in flake8 (don't forget to `chmod+x`) and then re-use i
   ]
 }
 ```
+
+## Uncommited steps (gitignore)
+
+Mookme steps are shared by default. The point of the tool is to provide a shared git hooks configuration. However we understand that sometimes, one would like to have a custom mookme configuration.
+
+You can use {hook-type}.local.json files that are located and formatted in the very same way that current hook files are.
+
+For instance, with the following configuration:
+
+```json
+// package1/.hooks/pre-commit.json
+{
+  "steps": [
+    {
+      "name": "common hook",
+      "command": "npm run lint:fix"
+    }
+  ]
+}
+```
+
+```json
+// package1/.hooks/pre-commit.local.json
+{
+  "steps": [
+    {
+      "name": "local hook",
+      "command": "npm test"
+    }
+  ]
+}
+```
+
+You will run both setps when committing. The difference between these two files is that `package1/.hooks/pre-commit.local.json` is git-ignored by default through the command-line project initialization.

--- a/packages/mookme/src/commands/init.ts
+++ b/packages/mookme/src/commands/init.ts
@@ -156,6 +156,9 @@ export function addInit(program: commander.Command): void {
         writeGitHooksFiles();
       }
 
+      logger.warning('\nAdding local hooks to .gitignore');
+      fs.appendFileSync(`./.gitignore`, `\n**/.hooks/*.local.json\n`, { flag: 'a+' });
+
       logger.success('Your hooks are configured.');
     });
 }

--- a/packages/mookme/src/commands/run.ts
+++ b/packages/mookme/src/commands/run.ts
@@ -13,6 +13,18 @@ interface Options {
   all: boolean;
 }
 
+export function addRun(program: commander.Command): void {
+  program
+    .command('run')
+    .requiredOption(
+      '-t, --type <type>',
+      'A valid git hook type ("pre-commit", "prepare-commit", "commit-msg", "post-commit")',
+    )
+    .option('-a, --all <all>', 'Run hooks for all packages', '')
+    .option('--args <args>', 'The arguments being passed to the hooks', '')
+    .action(run);
+}
+
 export async function run(opts: Options): Promise<void> {
   config.init();
   const initialNotStagedFiles = getNotStagedFiles();
@@ -49,16 +61,4 @@ export async function run(opts: Options): Promise<void> {
 
   // unstashIfNeeded(type);
   detectAndProcessModifiedFiles(initialNotStagedFiles, config.project.addedBehavior);
-}
-
-export function addRun(program: commander.Command): void {
-  program
-    .command('run')
-    .requiredOption(
-      '-t, --type <type>',
-      'A valid git hook type ("pre-commit", "prepare-commit", "commit-msg", "post-commit")',
-    )
-    .option('-a, --all <all>', 'Run hooks for all packages', '')
-    .option('--args <args>', 'The arguments being passed to the hooks', '')
-    .action(run);
 }

--- a/packages/mookme/tests/cases/use-local-hook.sh
+++ b/packages/mookme/tests/cases/use-local-hook.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+TESTS_DIR=$(mktemp -d)
+
+ROOT_FOLDER=$(realpath $(dirname "$0")/../..)
+npm run build &> /dev/null
+
+# create and cd in tmp folder
+cd $TESTS_DIR
+
+git init
+mkdir -p package1
+
+node $ROOT_FOLDER/dist/index.js init \
+    --yes \
+    --packages package1 \
+    --added-behaviour exit \
+    --packages-path "" > /dev/null
+
+echo '{"steps": [{"name": "Hello world !", "command": "echo 'hello'"}]}' > .hooks/pre-commit.json
+echo '{"steps": [{"name": "Hello world ! (local)", "command": "echo 'hello from local' > test.txt"}]}' > .hooks/pre-commit.local.json
+
+echo '{"steps": [{"name": "Hello world !", "command": "echo 'hello'"}]}' > package1/.hooks/pre-commit.json
+echo '{"steps": [{"name": "Hello world ! (local)", "command": "echo 'hello from package 1' > test-package.txt"}]}' > package1/.hooks/pre-commit.local.json
+
+git add .
+node $ROOT_FOLDER/dist/index.js run -t pre-commit
+
+if [ ! "$(grep -c "\*\*/.hooks/\*.local.json" .gitignore)" -eq 1 ]; then exit 1; fi;
+if [ ! "$(grep -c "hello from local" test.txt)" -eq 1 ]; then exit 1; fi;
+if [ ! "$(grep -c "hello from package 1" package1/test-package.txt)" -eq 1 ]; then exit 1; fi;


### PR DESCRIPTION
This pull request introduces the ability to have a `gitignored` mookme documentation. You can use `{hook-type}.local.json` files that are located and formatted in the very same way that current hook files are.

For instance, with the following configuration:

*package1/.hooks/pre-commit.json*
```
{
  "steps": [
    {
      "name": "common hook",
      "command": "npm run lint:fix"
    }
  ]
}

```

*package1/.hooks/pre-commit.local.json*
```
{
  "steps": [
    {
      "name": "local hook",
      "command": "npm test"
    }
  ]
}

```

You will run both setps when committing. The difference between these two files is that *package1/.hooks/pre-commit.local.json* is gitignored by default (line added by the init command)