### PR TITLE
Feat/select hook types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@commitlint/cli": "^12.1.1",
         "@commitlint/config-angular": "^12.1.1",
-        "@escape.tech/mookme": "^1.2.0-beta.2"
+        "@escape.tech/mookme": "^1.2.0-beta.7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -338,9 +338,9 @@
       }
     },
     "node_modules/@escape.tech/mookme": {
-      "version": "1.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@escape.tech/mookme/-/mookme-1.2.0-beta.2.tgz",
-      "integrity": "sha512-uGmQi7rsd/5EgZ7en+K4UfCtw23gazYYrCOsy2bp5tkQTcQ/4wTghCrTqoUFHtXD+USZVP3spk0COhewiMZAnw==",
+      "version": "1.2.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@escape.tech/mookme/-/mookme-1.2.0-beta.7.tgz",
+      "integrity": "sha512-9iUSBZUJCWxkWk7zdNpZUYvCKnhorTZBHOzbtibfmFURd5qP/3HBKpNPiw4PP6zudNqEhE/f+ipEFK7nMADMSA==",
       "dev": true,
       "dependencies": {
         "@types/node": "^15.0.2",
@@ -2344,9 +2344,9 @@
       }
     },
     "@escape.tech/mookme": {
-      "version": "1.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@escape.tech/mookme/-/mookme-1.2.0-beta.2.tgz",
-      "integrity": "sha512-uGmQi7rsd/5EgZ7en+K4UfCtw23gazYYrCOsy2bp5tkQTcQ/4wTghCrTqoUFHtXD+USZVP3spk0COhewiMZAnw==",
+      "version": "1.2.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@escape.tech/mookme/-/mookme-1.2.0-beta.7.tgz",
+      "integrity": "sha512-9iUSBZUJCWxkWk7zdNpZUYvCKnhorTZBHOzbtibfmFURd5qP/3HBKpNPiw4PP6zudNqEhE/f+ipEFK7nMADMSA==",
       "dev": true,
       "requires": {
         "@types/node": "^15.0.2",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "devDependencies": {
     "@commitlint/cli": "^12.1.1",
     "@commitlint/config-angular": "^12.1.1",
-    "@escape.tech/mookme": "^1.2.0-beta.2"
+    "@escape.tech/mookme": "^1.2.0-beta.7"
   }
 }

--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .vuepress/dist
+.hooks/*.local.json

--- a/packages/docs/README.md
+++ b/packages/docs/README.md
@@ -6,7 +6,7 @@
 
 ## What is Mookme ?
 
-Mookme is a Git hook manager. It's sole purpose is to execute some scripts when you want to commit. It could be a
+Mookme is a Git hook manager. It's sole purpose is to execute some scripts when you want to commit or do other git stuff. It could be a
 linter, tests, your favorite commit message checker.
 
 **Everything that is invoked through a cli can be used with Mookme!**
@@ -14,7 +14,7 @@ linter, tests, your favorite commit message checker.
 Despite being a very young project, it is ready to use, even if it remains a beta under active development.
 
 You are welcome to use it and enjoy it's simplicity.
-**If you encounter any bug or weird behavior, don't be afraid to open an issue :)**
+**If you encounter any bug or weird behavior, don't be afraid to open an [issue](https://github.com/Escape-Technologies/mookme/issues) :)**
 
 <img src="demo.gif" alt="A fresh look at your new git hooks ;)" width="600"/>
 

--- a/packages/docs/examples/README.md
+++ b/packages/docs/examples/README.md
@@ -2,7 +2,7 @@
 
 ## `commitlint`
 
-> This guide will help you in the setup of a hook a hook for linting your commits with [commitlint](https://github.com/conventional-changelog/commitlint)*
+> This guide will help you in the setup of a hook a hook for linting your commits with [commitlint](https://github.com/conventional-changelog/commitlint)
 
 ### Prerequisite
 

--- a/packages/docs/get-started/README.md
+++ b/packages/docs/get-started/README.md
@@ -3,7 +3,7 @@
 ## Installation
 
 ```bash
-npm install -g @escape.tech/mookme
+npm install @escape.tech/mookme
 ```
 
 ## Configuration
@@ -75,13 +75,26 @@ available git hooks, eg :
 - `prepare-commit-msg`
 - `commit-msg`
 - `post-commit`
+- `post-merge`,
+- `post-rewrite`,
+- `pre-rebase`,
+- `post-checkout`,
+- `pre-push`,
+
+::: warning
+The exit behavior is only applied on pre-commit hook types: `pre-commit`, `prepare-commit-msg`, `commit-msg`, `post-commit`
+:::
+
+::: warning
+If the command executed by a hook fails, it will prevent the git command to be executed. We recommend you to use the pre-receive hooks carefully, with relatively safe commands, otherwise you might prevent your team for doign stuff like `git pull` or `git fetch`.
+:::
 
 ### Example of hook file
 
 Your hooks are defined in simple json files.
 
-- For complete reference, see the JSON hooks reference
-- For specific hook examples, see the recipes
+- For complete reference, see the [JSON hooks reference](/references/#hook-files)
+- For specific hook examples, see the [recipes](/examples)
 
 A hook defines a list of `steps`, which are basically commands to run, with a name for proper display. A few
 configuration option are available, but the minimal requirement is `name` and `command`.

--- a/packages/docs/references/README.md
+++ b/packages/docs/references/README.md
@@ -6,17 +6,23 @@ The main initialization command. It :
 
 - prompts for one or multiple packages folder path
 - asks you to select one or multiple package at each path
+- asks you to selec one or multiple git event to hook
 - creates the `.hooks` folder in each package where you can write **dedicated hooks!** that will be triggered only
 when changes in this package occur
 - creates a `.hooks` folder at the root of your project where you can write **project-wide hooks** that will be
 triggered on every commit
 - writes `.git/hooks` files
+- writes into the `.gitignore` files of your root project and specified packages to ignore [local steps](/features/#uncommited-steps-gitignore)
 
 ### Options
 
 - `--only-hook` (optional)
 
 Skip prompters and only write `.git/hooks` files. This is for installation in an already-configured project.
+
+- `--skip-types-selection` (optional)
+
+Skip hook types selection and hook every git event.
 
 ## `mookme add-pkg`
 
@@ -66,13 +72,9 @@ Skip the selection of hooks to run based on git-staged files, and run hooks of e
 
 ## Hook files
 
-With `mookme`, your hooks are stored in JSON files called `{hook-type}.json` where the hook type is one of the
-available git hooks, eg :
+### General description
 
-- `pre-commit`
-- `prepare-commit-msg`
-- `commit-msg`
-- `post-commit`
+See [Writing your hooks](/get-started/#writing-your-hooks)
 
 ### Available options
 
@@ -88,13 +90,15 @@ The list of steps (commands) being executed by this hook. In a step you can defi
 | `cmd`      | The command invoked at this step |   yes |
 | `onlyOn` | A shell wildcard conditioning the execution of the step based on modified files      |    no |
 | `serial` | A boolean value describing if the package hook execution should await for the step to end |    no |
+| `from` | Extend a shared step |    no |
 
 ::: warning
 A serial step that fails will not prevent the execution of the following steps
+:::
 
 - `type`
 
-A flag used mainly to tell `mookme` this is a python hook, and might need a virtual environment to be activated.
+A flag used mainly to tell `mookme` this is a python hook, and might need a virtual environment to be activated. Possible values are `python, js, script`
 
 - `venvActivate`
 

--- a/packages/mookme/.gitignore
+++ b/packages/mookme/.gitignore
@@ -3,3 +3,4 @@ dist
 .tmp
 coverage
 tests/logs/*.log
+.hooks/*.local.json

--- a/packages/mookme/src/commands/init.ts
+++ b/packages/mookme/src/commands/init.ts
@@ -113,6 +113,15 @@ export function addInit(program: commander.Command): void {
       logger.info('\nThe following configuration will be written into .mookme.json:');
       logger.log(JSON.stringify(mookMeConfig, null, 2));
 
+      logger.info('\n The follwowing git hooks will be created:');
+      hookTypes.forEach((t) => logger.log(`./.git/hooks/${t}`));
+
+      logger.info('\n`.hooks/*.local.env` will be appended into the following `.gitignore` files:');
+      selectedPackages
+        .map((mod) => `${mookMeConfig.packagesPath}/${mod}/.gitignore`)
+        .forEach((p) => logger.log(`- ${p}`));
+      logger.log(`- ./.gitignore`);
+
       logger.info('\nThe following directories will also be created:');
       packagesHooksDirPaths.forEach((hookDir) => logger.log(`- ${hookDir}`));
       logger.log(`- ./.hooks`);
@@ -166,6 +175,8 @@ export function addInit(program: commander.Command): void {
         });
 
         writeGitHooksFiles(hookTypes);
+        const paths = mookMeConfig.packages.map((pkg) => `${mookMeConfig.packagesPath}/${pkg}`);
+        paths.push('./.gitignore');
         writeGitIgnoreFiles(mookMeConfig.packages.map((pkg) => `${mookMeConfig.packagesPath}/${pkg}`));
       }
 

--- a/packages/mookme/src/prompts/init.ts
+++ b/packages/mookme/src/prompts/init.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk';
 import fs from 'fs';
+import inquirer from 'inquirer';
 import { ADDED_BEHAVIORS } from '../config/types';
+import { HookType, hookTypes } from '../types/hook.types';
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const folderQuestion = (name: string, from = '') => ({
@@ -30,6 +32,19 @@ export const choiceQuestion = (name: string, message: string, choices: string[])
   choices,
   pageSize: process.stdout.rows / 2,
 });
+
+export async function selectHookTypes(skip = false): Promise<HookType[]> {
+  let typesToHook: HookType[];
+  if (skip) {
+    typesToHook = hookTypes;
+  } else {
+    const { types } = (await inquirer.prompt([
+      choiceQuestion('types', 'Select git events to hook :\n', hookTypes),
+    ])) as { types: HookType[] };
+    typesToHook = types;
+  }
+  return typesToHook;
+}
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const confirmQuestion = (name: string, message: string) => ({

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
-import { HookType, hookTypes } from '../types/hook.types';
+import { HookType } from '../types/hook.types';
 import { ADDED_BEHAVIORS } from '../config/types';
 import config from '../config';
 import logger from '../display/logger';
@@ -78,7 +78,7 @@ export function detectAndProcessModifiedFiles(initialNotStagedFiles: string[], b
   }
 }
 
-export function writeGitHooksFiles(rootDir = '.'): void {
+export function writeGitHooksFiles(hookTypes: HookType[], rootDir = '.'): void {
   const gitFolderPath = `${rootDir}/.git`;
   if (!fs.existsSync(`${gitFolderPath}/hooks`)) {
     fs.mkdirSync(`${gitFolderPath}/hooks`);
@@ -120,7 +120,11 @@ export function writeGitIgnoreFiles(packagesPath: string[]): void {
       logger.warning(`Package ${pkgPath} has no \`.gitignore\` file, creating it...`);
       fs.writeFileSync(`${pkgPath}/.gitignore`, `.hooks/*.local.json\n`);
     } else {
-      fs.appendFileSync(`${pkgPath}/.gitignore`, `\n.hooks/*.local.json\n`, { flag: 'a+' });
+      const line = '.hooks/*.local.json';
+      const gitignoreContent = fs.readFileSync(`${pkgPath}/.gitignore`).toString();
+      if (gitignoreContent.includes(line)) {
+        fs.appendFileSync(`${pkgPath}/.gitignore`, `\n.hooks/*.local.json\n`, { flag: 'a+' });
+      }
     }
   }
 }

--- a/packages/mookme/tests/cases/add-pkg.sh
+++ b/packages/mookme/tests/cases/add-pkg.sh
@@ -15,6 +15,7 @@ node $ROOT_FOLDER/dist/index.js init \
     --yes \
     --packages package1 \
     --added-behaviour exit \
+    --skip-types-selection \
     --packages-path "" > /dev/null
 
 mkdir -p package2

--- a/packages/mookme/tests/cases/non-existant-command.sh
+++ b/packages/mookme/tests/cases/non-existant-command.sh
@@ -15,6 +15,7 @@ node $ROOT_FOLDER/dist/index.js init \
     --yes \
     --packages package1 \
     --added-behaviour exit \
+    --skip-types-selection \
     --packages-path ""
 
 echo '{"steps": [{"name": "Custom Command", "command": "get-dir-name"}]}' > package1/.hooks/pre-commit.json

--- a/packages/mookme/tests/cases/pre-commit-fails.sh
+++ b/packages/mookme/tests/cases/pre-commit-fails.sh
@@ -15,6 +15,7 @@ node $ROOT_FOLDER/dist/index.js init \
     --yes \
     --packages package1 \
     --added-behaviour exit \
+    --skip-types-selection \
     --packages-path ""
 
 echo '{"steps": [{"name": "Oups", "command": "exit 1"}]}' > package1/.hooks/pre-commit.json

--- a/packages/mookme/tests/cases/pre-commit-succeeds.sh
+++ b/packages/mookme/tests/cases/pre-commit-succeeds.sh
@@ -17,6 +17,7 @@ node $ROOT_FOLDER/dist/index.js init \
     --yes \
     --packages package1 "parent1/package2" "parent1/package3" \
     --added-behaviour exit \
+    --skip-types-selection \
     --packages-path ""
 
 {

--- a/packages/mookme/tests/cases/use-local-hook.sh
+++ b/packages/mookme/tests/cases/use-local-hook.sh
@@ -15,6 +15,7 @@ node $ROOT_FOLDER/dist/index.js init \
     --yes \
     --packages package1 \
     --added-behaviour exit \
+    --skip-types-selection \
     --packages-path "" > /dev/null
 
 echo '{"steps": [{"name": "Hello world !", "command": "echo 'hello'"}]}' > .hooks/pre-commit.json


### PR DESCRIPTION
When a new project is initialized, this feature allows the user to select a list of git events to hook.

By default, none of them are, and you can pick up events as you wish.
This behaviour is also present with `--only-hook`, allowing to select to what extend you want mookme to be used in your local installation.

An option on the init command `--skip-types-selection` allows to skip this prompter. In this case, all of the events are selected.

`--skip-types-selection` and `--only-hook` can be used together