### PR TITLE
Fix commit hooks without staged files

### DIFF
--- a/packages/mookme/src/loaders/hooks-resolver.ts
+++ b/packages/mookme/src/loaders/hooks-resolver.ts
@@ -18,9 +18,10 @@ function matchExactPath(filePath: string, to_match: string): boolean {
  * A class defining several utilitaries used to load and prepare packages hooks to be executed
  */
 export class HooksResolver {
-  gitToolkit: GitToolkit;
-  root: string;
-  hookType: string;
+  private static readonly stagingHooks = ['pre-commit'];
+  private readonly gitToolkit: GitToolkit;
+  private readonly root: string;
+  private readonly hookType: string;
 
   /**
    * A class defining several utilitaries used to load and prepare packages hooks to be executed
@@ -200,6 +201,10 @@ export class HooksResolver {
    * @returns the filtered list of {@link PackageHook} based on their consistency with the files staged in VCS.
    */
   filterWithVCS(hooks: PackageHook[]): PackageHook[] {
+    if (!HooksResolver.stagingHooks.includes(this.hookType)) {
+      return hooks;
+    }
+
     const { staged: stagedFiles } = this.gitToolkit.getVCSState();
 
     const filtered = hooks.filter((hook) => {
@@ -244,5 +249,9 @@ export class HooksResolver {
     hooks = this.filterWithVCS(hooks);
 
     return hooks;
+  }
+
+  getHookType(): string {
+    return this.hookType;
   }
 }

--- a/packages/mookme/src/runner/inspect.ts
+++ b/packages/mookme/src/runner/inspect.ts
@@ -14,7 +14,7 @@ export class InspectRunner {
 
   async run(): Promise<void> {
     const root = process.cwd();
-    const hookType = this.resolver.hookType;
+    const hookType = this.resolver.getHookType();
 
     logger.info('');
     logger.info(`Step 1: Looking for packages under the folder '${root}'`);

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -28,17 +28,18 @@ export class GitToolkit {
   }
 
   getNotStagedFiles(): string[] {
-    return execSync('echo $(git diff --name-only)')
-      .toString()
-      .split(' ')
-      .map((pth) => pth.replace('\n', ''));
+    return GitToolkit.gitFileList('git diff --name-only -z');
   }
 
   getStagedFiles(): string[] {
-    return execSync('echo $(git diff --cached --name-only)')
+    return GitToolkit.gitFileList('git diff --cached --name-only -z');
+  }
+
+  private static gitFileList(command: string): string[] {
+    return execSync(command)
       .toString()
-      .split(' ')
-      .map((pth) => pth.replace('\n', ''));
+      .split('\0')
+      .filter((p) => p !== '');
   }
 
   getVCSState(): { staged: string[]; notStaged: string[] } {
@@ -49,10 +50,7 @@ export class GitToolkit {
   }
 
   detectAndProcessModifiedFiles(initialNotStagedFiles: string[], behavior: ADDED_BEHAVIORS): void {
-    const notStagedFiles = execSync('echo $(git diff --name-only)')
-      .toString()
-      .split(' ')
-      .map((file) => file.replace('\n', ''));
+    const notStagedFiles = this.getNotStagedFiles();
 
     const changedFiles = notStagedFiles.filter((file) => !initialNotStagedFiles.includes(file));
     if (changedFiles.length > 0) {

--- a/packages/mookme/tests/cases/post-commit-fails.sh
+++ b/packages/mookme/tests/cases/post-commit-fails.sh
@@ -10,14 +10,15 @@ npm run build &> /dev/null
 cd $TESTS_DIR
 
 git init -q
-mkdir -p package1
-mkdir -p package1/.hooks
+
+mkdir -p .hooks
+echo '{"steps": [{"name": "Oups", "command": "exit 1"}]}' > .hooks/post-commit.json
+git add .
+git commit -m "Set up hooks"
 
 node $ROOT_FOLDER/dist/index.js init \
     --yes \
     --added-behaviour exit \
-    --skip-types-selection \
+    --skip-types-selection
 
-echo '{"steps": [{"name": "Custom Command", "command": "get-dir-name"}]}' > package1/.hooks/pre-commit.json
-git add .
-! node $ROOT_FOLDER/dist/index.js run -t pre-commit
+! node $ROOT_FOLDER/dist/index.js run -t post-commit

--- a/packages/mookme/tests/cases/post-commit-succeeds.sh
+++ b/packages/mookme/tests/cases/post-commit-succeeds.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+TESTS_DIR=$(mktemp -d)
+
+ROOT_FOLDER=$(realpath $(dirname "$0")/../..)
+npm run build &> /dev/null
+
+# create and cd in tmp folder
+cd $TESTS_DIR
+
+git init -q
+mkdir -p .hooks/partials
+mkdir -p package1
+mkdir -p parent1/package2
+mkdir -p parent1/package3/.hooks
+
+{
+  echo '#!/usr/bin/env bash'
+  echo 'basename "$(pwd)"'
+} > .hooks/partials/get-dir-name
+chmod +x .hooks/partials/get-dir-name
+
+echo '{"steps": [{"name": "Hello world !", "command": "echo 'hello'"}]}' > .hooks/post-commit.json
+echo '{"steps": [{"name": "Hello world !", "command": "[  $(get-dir-name) = 'package3' ]"}]}' > parent1/package3/.hooks/post-commit.json
+
+git add .
+git commit -m "Set up hooks"
+
+node $ROOT_FOLDER/dist/index.js init \
+    --yes \
+    --added-behaviour exit \
+    --skip-types-selection
+
+node $ROOT_FOLDER/dist/index.js run -t post-commit

--- a/packages/mookme/tests/cases/pre-commit-fails.sh
+++ b/packages/mookme/tests/cases/pre-commit-fails.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 TESTS_DIR=$(mktemp -d)
 
@@ -8,7 +9,7 @@ npm run build &> /dev/null
 # create and cd in tmp folder
 cd $TESTS_DIR
 
-git init
+git init -q
 mkdir -p package1
 mkdir -p package1/.hooks
 

--- a/packages/mookme/tests/cases/pre-commit-succeeds.sh
+++ b/packages/mookme/tests/cases/pre-commit-succeeds.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 TESTS_DIR=$(mktemp -d)
 
@@ -8,7 +9,7 @@ npm run build &> /dev/null
 # create and cd in tmp folder
 cd $TESTS_DIR
 
-git init
+git init -q
 mkdir -p package1
 mkdir -p parent1/package2
 mkdir -p parent1/package3

--- a/packages/mookme/tests/cases/use-local-hook.sh
+++ b/packages/mookme/tests/cases/use-local-hook.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 TESTS_DIR=$(mktemp -d)
 
@@ -8,7 +9,7 @@ npm run build &> /dev/null
 # create and cd in tmp folder
 cd $TESTS_DIR
 
-git init
+git init -q
 mkdir -p package1
 mkdir -p package1/.hooks
 


### PR DESCRIPTION
Changes `HooksResolver.filterWithVCS()` so that it only filters for hooks that will have staging areas.

Fixes https://github.com/Escape-Technologies/mookme/issues/63