### PR TITLE
feat(mookme): add a debugger for development usage

### DIFF
--- a/packages/mookme/package-lock.json
+++ b/packages/mookme/package-lock.json
@@ -12,6 +12,7 @@
         "@types/node": "^15.0.2",
         "chalk": "^4.1.1",
         "commander": "^7.2.0",
+        "debug": "^4.3.4",
         "inquirer": "^8.0.0",
         "wildcard-match": "^5.1.0"
       },
@@ -22,6 +23,7 @@
         "@semantic-release/changelog": "^6.0.0",
         "@semantic-release/git": "^10.0.0",
         "@tsconfig/node10": "^1.0.7",
+        "@types/debug": "^4.1.7",
         "@types/inquirer": "^7.3.1",
         "@typescript-eslint/eslint-plugin": "4.22.1",
         "@typescript-eslint/parser": "4.22.1",
@@ -576,6 +578,15 @@
       "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
       "dev": true
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/inquirer": {
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.3.tgz",
@@ -602,6 +613,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -1457,10 +1474,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3714,8 +3730,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -9032,6 +9047,15 @@
       "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
       "dev": true
     },
+    "@types/debug": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
+    },
     "@types/inquirer": {
       "version": "7.3.3",
       "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-7.3.3.tgz",
@@ -9058,6 +9082,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
       "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
       "dev": true
     },
     "@types/node": {
@@ -9653,10 +9683,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -11375,8 +11404,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/packages/mookme/package.json
+++ b/packages/mookme/package.json
@@ -47,6 +47,7 @@
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/git": "^10.0.0",
     "@tsconfig/node10": "^1.0.7",
+    "@types/debug": "^4.1.7",
     "@types/inquirer": "^7.3.1",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",
@@ -63,6 +64,7 @@
     "@types/node": "^15.0.2",
     "chalk": "^4.1.1",
     "commander": "^7.2.0",
+    "debug": "^4.3.4",
     "inquirer": "^8.0.0",
     "wildcard-match": "^5.1.0"
   }

--- a/packages/mookme/src/commands/init.ts
+++ b/packages/mookme/src/commands/init.ts
@@ -1,6 +1,9 @@
 import commander from 'commander';
 import { GitToolkit } from '../utils/git';
 import { InitOptions, InitRunner } from '../runner/init';
+import Debug from 'debug';
+
+const debug = Debug('mookme');
 
 export function addInit(program: commander.Command): void {
   program
@@ -10,6 +13,7 @@ export function addInit(program: commander.Command): void {
     .option('--skip-types-selection', 'Skip hook types selection')
     .option('--yes', 'Skip confirmation prompter')
     .action(async (opts: InitOptions) => {
+      debug('Running init command with options', opts);
       const git = new GitToolkit();
       const initRunner = new InitRunner(git);
       await initRunner.run(opts);

--- a/packages/mookme/src/debug.ts
+++ b/packages/mookme/src/debug.ts
@@ -1,0 +1,2 @@
+import Debug from 'debug';
+export const debug = Debug('mookme');

--- a/packages/mookme/src/ui/writer.ts
+++ b/packages/mookme/src/ui/writer.ts
@@ -1,5 +1,8 @@
 import chalk from 'chalk';
 
+import Debug from 'debug';
+const debug = Debug('mookme:writer');
+
 /**
  * A small wrapper around process.stdout.write, ensuring
  * we do not log below the console, making it scroll.
@@ -10,10 +13,19 @@ export class ConsoleCanvas {
   private _currentRow = 0;
   private _warningWritten = false;
 
+  private debugMode: boolean;
+
+  constructor() {
+    this.debugMode = process.env.DEBUG ? process.env.DEBUG.includes('mookme') : false;
+  }
+
   /**
    * Clear the console, and reset the lines count
    */
   clear(): void {
+    if (this.debugMode) {
+      return;
+    }
     this._currentRow = 0;
     this._warningWritten = false;
     console.clear();
@@ -25,6 +37,10 @@ export class ConsoleCanvas {
    * @param line - the line to write
    */
   write(line = ''): void {
+    if (this.debugMode) {
+      debug(`Line to write with value "${line}"`);
+      return;
+    }
     if (this._currentRow + 1 < process.stdout.rows - 1) {
       process.stdout.write(line);
       process.stdout.write('\n');

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -5,6 +5,9 @@ import { ADDED_BEHAVIORS } from '../config/types';
 import logger from './logger';
 import { getRootDir } from './root-dir';
 
+import Debug from 'debug';
+const debug = Debug('mookme:git');
+
 /**
  * A helper class for performing git operations
  */
@@ -19,7 +22,10 @@ export class GitToolkit {
    *
    */
   constructor() {
+    debug('Initializing git toolkit');
     const rootDir = getRootDir('.git');
+    debug(`Found root at path ${rootDir}`);
+
     if (!rootDir) {
       logger.failure('Could not find a git project');
       process.exit(0);


### PR DESCRIPTION
# Description

- Added the usual [debug](https://www.npmjs.com/package/debug) dependency for writing system information when running mookme
- Added a flag in the `Writer` class for skipping the rendering of the UI when the command is invoked with `"mookme"` in the environment variable `process.env.DEBUG`

Debug statement are very sparse so far but I expect them to proliferate along further developments.

## Usage

Step 1: Add your debug statements. Examples are in `src/commands/init.ts`, `src/ui/writer.ts`.

```ts
import Debug from 'debug';

const debug = Debug('mookme'); // Or Debug('mookme:<filename>');
```

Step 2: Call the instantiated debugger

```ts
debug('Some statement')
```

Step 3: Call Mookme with the appropriate environment

```
DEBUG=mookme:* node /path/to/mookme/dist/index.js <command>
```

## Example output

<img width="736" alt="image" src="https://user-images.githubusercontent.com/29194680/159371139-b13a1e7b-9c53-4c7c-8a83-f0986dbcf5fb.png">
