### PR TITLE
feat(mookme): attach matched files to step objects

### DIFF
--- a/packages/docs/get-started/README.md
+++ b/packages/docs/get-started/README.md
@@ -12,7 +12,7 @@ npm install @escape.tech/mookme
 
 ## Configuration
 
-Mookme will look automatically detect the `.hooks` folder across your repository and trigger the command related to your current VCS state.
+Mookme will automatically detect the `.hooks` folder across your repository and trigger the command related to your current VCS state.
 
 Hence it only requires a very minimal configuration, as most of this is defined by where you place your `.hooks` folders, and what you put in them.
 
@@ -90,6 +90,20 @@ The exit behavior is only applied on pre-commit hook types: `pre-commit`, `prepa
 ::: warning
 If the command executed by a hook fails, it will prevent the git command to be executed. We recommend you to use the pre-receive hooks carefully, with relatively safe commands, otherwise you might prevent your team for doign stuff like `git pull` or `git fetch`.
 :::
+
+### How will Mookme decide which hooks to run ?
+
+1. Based on the hook type being executed, Mookme will pick a strategy for selecting files concerned by an execution. For instance:
+
+- When running a `pre-commit` hook, Mookme will select the current staged files in the repository
+- When running a `post-commit` hook, Mookme will select the files commited in the last commit
+The result of this step is a list of relative paths from the root of the repository.
+
+<!-- markdownlint-disable MD001 MD029 -->
+2. For each folder where a `.hooks` folder is found, Mookme will assess if there are file paths in the previous list matching the relative path to this folder from the root of the repository. For each matched package, the list of matched paths is attached to it, and the same paths, but relative from the package itself (where the `.hooks` folder is located) are attached to the step objects.
+
+<!-- markdownlint-disable MD001 MD029 -->
+3. Other selections (`onlyOn` for instance) are applied on each step of each package, based on the list of paths attached to the package and it's steps.
 
 ### Example of hook file
 

--- a/packages/docs/references/README.md
+++ b/packages/docs/references/README.md
@@ -83,6 +83,10 @@ The list of steps (commands) being executed by this hook. In a step you can defi
 A serial step that fails will not prevent the execution of the following steps
 :::
 
+::: warning
+The pattern provided in `onlyOn` will be matched agains the relative path of matched files of the execution, from the package folder, not from the repository root.
+:::
+
 - `type`
 
 A flag used mainly to tell `mookme` this is a python hook, and might need a virtual environment to be activated. Possible values are `python, js, script`

--- a/packages/mookme/src/executor/package-executor.ts
+++ b/packages/mookme/src/executor/package-executor.ts
@@ -6,10 +6,6 @@ import { ExecutionStatus } from '../types/status.types';
 
 export interface PackageExecutorOptions {
   /**
-   * The arguments provided to the git hooks command
-   */
-  hookArguments: string;
-  /**
    * The list of staged files in the current copy
    */
   stagedFiles: string[];
@@ -44,7 +40,6 @@ export class PackageExecutor {
           packagePath: pkg.cwd,
           type: pkg.type,
           venvActivate: pkg.venvActivate,
-          hookArguments: options.hookArguments,
           stagedFiles: options.stagedFiles,
           rootDir: options.rootDir,
         }),

--- a/packages/mookme/src/loaders/filter-strategies/base-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/base-filter.ts
@@ -1,10 +1,17 @@
-import { PackageHook } from '../../types/hook.types';
+import { PackageHook, UnprocessedPackageHook } from '../../types/hook.types';
 
 /**
  * A base class for denoting a strategy used to filter hooks to run
  */
 export abstract class FilterStrategy {
-  async filter(hooks: PackageHook[]): Promise<PackageHook[]> {
-    return hooks;
+  async filter(hooks: UnprocessedPackageHook[]): Promise<PackageHook[]> {
+    return hooks.map((hook) => ({
+      ...hook,
+      matchedFiles: [],
+      steps: hook.steps.map((step) => ({
+        ...step,
+        matchedFiles: [],
+      })),
+    }));
   }
 }

--- a/packages/mookme/src/loaders/filter-strategies/current-commit-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/current-commit-filter.ts
@@ -1,7 +1,10 @@
+import Debug from 'debug';
 import path from 'path';
-import { PackageHook } from '../../types/hook.types';
+import { PackageHook, UnprocessedPackageHook } from '../../types/hook.types';
 import { GitToolkit } from '../../utils/git';
 import { FilterStrategy } from './base-filter';
+
+const debug = Debug('mookme:filtering-strategy');
 
 /**
  * Filter a list of packages based on the VCS state, and the staged files it holds.
@@ -31,12 +34,34 @@ export class CurrentCommitFilterStrategy extends FilterStrategy {
    * @param hooks - the list of {@link PackageHook} to filter
    * @returns the filtered list of {@link PackageHook} based on their consistency with the files staged in VCS.
    */
-  async filter(hooks: PackageHook[]): Promise<PackageHook[]> {
+  async filter(hooks: UnprocessedPackageHook[]): Promise<PackageHook[]> {
     const { staged: stagedFiles } = this.gitToolkit.getVCSState();
 
-    const filtered = hooks.filter((hook) => {
-      return !!stagedFiles.find((file) => this.matchExactPath(path.join(this.gitToolkit.rootDir, file), hook.cwd));
-    });
+    const filtered: PackageHook[] = [];
+
+    for (const unprocessedHook of hooks) {
+      // Detect if the current commit includes files concerning this hook
+      const matchedFiles = stagedFiles.filter((file) =>
+        this.matchExactPath(path.join(this.gitToolkit.rootDir, file), unprocessedHook.cwd),
+      );
+      if (matchedFiles.length > 0) {
+        debug(`Adding ${unprocessedHook.name} because there are ${matchedFiles.length} files matching it's path`);
+        // Include the matched files in the hook and it's steps
+        filtered.push({
+          ...unprocessedHook,
+          steps: unprocessedHook.steps.map((step) => ({
+            ...step,
+            // Make the step matched paths relative to the cwd of the package they belong to
+            matchedFiles: matchedFiles.map((fPath) =>
+              path.join(this.gitToolkit.rootDir, fPath).replace(`${unprocessedHook.cwd}/`, ''),
+            ),
+          })),
+          matchedFiles,
+        });
+      } else {
+        debug(`Skipping hook ${unprocessedHook.name} because there are no match between it's path and staged files`);
+      }
+    }
 
     return filtered;
   }

--- a/packages/mookme/src/runner/inspect.ts
+++ b/packages/mookme/src/runner/inspect.ts
@@ -1,5 +1,5 @@
 import { HooksResolver } from '../loaders/hooks-resolver';
-import { PackageHook } from '../types/hook.types';
+import { UnprocessedPackageHook } from '../types/hook.types';
 import logger from '../utils/logger';
 
 /**
@@ -53,7 +53,7 @@ export class InspectRunner {
     logger.info('');
 
     // Step 3: Build the list of available steps, including local ones. Also load the package information
-    let hooks: PackageHook[] = this.resolver.loadPackages(packagesPathForHookType);
+    let hooks: UnprocessedPackageHook[] = this.resolver.loadPackages(packagesPathForHookType);
 
     // Step 4: Interpolate step's content in case of shared steps
     hooks = this.resolver.interpolateSharedSteps(hooks);

--- a/packages/mookme/src/runner/run.ts
+++ b/packages/mookme/src/runner/run.ts
@@ -68,13 +68,14 @@ export class RunRunner {
     this.hooksResolver.setupPATH();
 
     // Load packages hooks to run
-    const hooks = await this.hooksResolver.getPreparedHooks(opts.type);
+    let hooks = await this.hooksResolver.getPreparedHooks();
+    hooks = this.hooksResolver.applyOnlyOn(hooks);
+    hooks = this.hooksResolver.hydrateArguments(hooks, hookArguments);
 
     // Instanciate the package executors
     const packageExecutors = hooks.map(
       (pkg) =>
         new PackageExecutor(pkg, {
-          hookArguments,
           stagedFiles: initialStagedFiles,
           rootDir: this.gitToolkit.rootDir,
         }),

--- a/packages/mookme/src/types/hook.types.ts
+++ b/packages/mookme/src/types/hook.types.ts
@@ -1,4 +1,4 @@
-import { StepCommand } from './step.types';
+import { StepCommand, UnprocessedStepCommand } from './step.types';
 
 /**
  * An enum of supported git hook types
@@ -37,7 +37,7 @@ export enum PackageType {
   PYTHON = 'python',
   JS = 'js',
 }
-export interface PackageHook {
+export interface UnprocessedPackageHook {
   /**
    * The displayed name of the package
    */
@@ -45,7 +45,7 @@ export interface PackageHook {
   /**
    * The list of step descriptors executed with the hook
    */
-  steps: StepCommand[];
+  steps: UnprocessedStepCommand[];
   /**
    * The directory where the package is stored
    */
@@ -58,4 +58,9 @@ export interface PackageHook {
    * A boolean denoting whether a virtualenv is started of not for this hook (eg for Python)
    */
   venvActivate?: string;
+}
+
+export interface PackageHook extends UnprocessedPackageHook {
+  matchedFiles: string[];
+  steps: StepCommand[];
 }

--- a/packages/mookme/src/types/step.types.ts
+++ b/packages/mookme/src/types/step.types.ts
@@ -4,7 +4,7 @@ import { PackageHook } from './hook.types';
  * An interface describing the step object used across the codebase
  *
  */
-export interface StepCommand {
+export interface UnprocessedStepCommand {
   /**
    *  The named of the step. Displayed in the UI and used in it to index steps and hooks
    */
@@ -22,9 +22,13 @@ export interface StepCommand {
    */
   serial?: boolean;
   /**
-   *  Does this step extend a partial
+   *  Does this step extend a shared step
    */
   from?: string;
+}
+
+export interface StepCommand extends UnprocessedStepCommand {
+  matchedFiles: string[];
 }
 
 /**

--- a/packages/mookme/src/ui/index.ts
+++ b/packages/mookme/src/ui/index.ts
@@ -110,7 +110,7 @@ export class MookmeUI {
    * @see {@link Events} for payload's description
    */
   onPackageRegistered(data: Events[EventType.PackageRegistered]): void {
-    debug(`Received event "PackageRegistered" with payload ${data}`);
+    debug(`Received event "PackageRegistered" with payload ${JSON.stringify(data)}`);
     this.packages.push({
       name: data.name,
       status: ExecutionStatus.CREATED,
@@ -128,7 +128,7 @@ export class MookmeUI {
    * @see {@link Events} for payload's description
    */
   onStepRegistered(data: Events[EventType.StepRegistered]): void {
-    debug(`Received event "StepRegistered" with payload ${data}`);
+    debug(`Received event "StepRegistered" with payload ${JSON.stringify(data)}`);
     const pkg = this.packages.find((pkg) => pkg.name === data.packageName);
     if (pkg) {
       pkg.steps.push({
@@ -147,7 +147,7 @@ export class MookmeUI {
    * @see {@link Events} for payload's description
    */
   onStepStatusChange(data: Events[EventType.StepStatusChanged]): void {
-    debug(`Received event "StepStatusChange" with payload ${data}`);
+    debug(`Received event "StepStatusChange" with payload ${JSON.stringify(data)}`);
     const pkg = this.packages.find((pkg) => pkg.name === data.packageName);
     if (pkg) {
       const step = pkg.steps.find((step) => step.name === data.stepName);

--- a/packages/mookme/src/utils/run-helpers.ts
+++ b/packages/mookme/src/utils/run-helpers.ts
@@ -1,24 +1,5 @@
-import path from 'path';
-import wcmatch from 'wildcard-match';
 import { StepError } from '../types/step.types';
 import logger from './logger';
-
-export function getMatchedFiles(
-  pattern: string,
-  packagePath: string,
-  stagedFiles: string[] | undefined,
-  rootDir: string,
-): string[] {
-  const matcher = wcmatch(pattern);
-
-  return (stagedFiles || [])
-    .map((fPath: string) => path.join(rootDir, fPath))
-    .filter((fPath: string) => {
-      return fPath.includes(packagePath);
-    })
-    .map((fPath: string) => fPath.replace(`${packagePath}/`, ''))
-    .filter((rPath: string) => matcher(rPath));
-}
 
 export function processResults(results: StepError[][]): void {
   results.forEach((packageErrors) => {


### PR DESCRIPTION
# Description

As mentionned in #58, I have refactored the hook resolution process, so that it is based on a list of matched files, and this list is attached to both the hook object, and the step object.

The process is now as follows:

1. Available hooks are dynamically resolved based on if there is a `.hooks` folder with a `{hook-type}.json` file in it.

2. These available hooks are filtered, based on a strategy attaching a list of matched files to the package and it's steps.

- For the `pre-commit` hook for instance, we use the `CurrentCommitFilterStrategy`, comparing the list of staged files with the path of the package. It will set `hooks.matchedFiles` to a list containing the relative paths from the **repository root** , and `hooks.steps.matchedFiles` to a list containing the relative paths from the **package directory**. If `hooks.matchedFiles` has a length greater than 0 after this step, the hook is included into the list of hooks to run.

3. The steps within the filtered hooks are then filtered based on an eventual `onlyOn` pattern. Here, this filtering is simply removing the files not matching the pattern from the step's `matchedFiles` list. This is useful to display that the step is skipped in the UI afterwards.

4. Arguments are interpolated in the steps commands. This is where we'll pass the list of matched files of the step to the command in a short future. So far only the `args` parameter is interpolated as before.

5. This final list of hooks, with steps having a proper list of matched files, are passed to the step executor for being executed.

# Other improvements

- The `HooksResolver` class features a lot of debugging statements
- The `CurrentCommitFilterStrategy` features a lot of debugging statements