### PR TITLE
Added arguments for steps

### DIFF
--- a/packages/docs/references/README.md
+++ b/packages/docs/references/README.md
@@ -94,3 +94,33 @@ A flag used mainly to tell `mookme` this is a python hook, and might need a virt
 - `venvActivate`
 
 A path to a `<venv>/bin/activate` script to execute before the command if the hook type is `python`
+
+### Available arguments
+
+A set of arguments is provided by Mookme, that can be directly used in the hooks command definitions using the following syntax in the step definition:
+
+````json
+{
+    "command": "run-something {args}" // Will be replaced with the value of `args`
+}
+````
+
+- `args`
+
+The argument being passed by git to the hook file. See [the Git documentation on the hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) for more details about what it contains depending on the hook type being executed.
+
+- `stagedFiles`
+
+The list of files being matched by the package filtering strategy, and responsible for it being ran in this execution. The files are separated by a blank space (" "). See [the section about how Mookme selects packages to run](/get-started/#how-will-mookme-decide-which-hooks-to-run) for more details on how the files passed in this are selected.
+
+::: warning
+The paths are relative from the repository root folder
+:::
+
+- `matchedFiles`
+
+The list of files being matched by the step filtering strategy, and responsible for it being ran in this execution. The files are separated by a blank space (" "). See [the section about how Mookme selects packages to run](/get-started/#how-will-mookme-decide-which-hooks-to-run) for more details on how the files passed in this are selected.
+
+::: warning
+The paths are relative from the package folder (eg, the folder where the `.hooks` folder was detected)
+:::

--- a/packages/mookme/src/commands/run.ts
+++ b/packages/mookme/src/commands/run.ts
@@ -21,7 +21,7 @@ export function addRun(program: commander.Command): void {
       '-t, --type <type>',
       'A valid git hook type ("pre-commit", "prepare-commit", "commit-msg", "post-commit")',
     )
-    .option('-a, --all <all>', 'Run hooks for all packages', '')
+    .option('-a, --all', 'Run hooks for all packages', '')
     .option('--args <args>', 'The arguments being passed to the hooks', '')
     .action(async (opts: RunOptions) => {
       debug('Running run command with options', opts);

--- a/packages/mookme/src/loaders/filter-strategies/current-commit-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/current-commit-filter.ts
@@ -11,13 +11,15 @@ const debug = Debug('mookme:filtering-strategy');
  */
 export class CurrentCommitFilterStrategy extends FilterStrategy {
   gitToolkit: GitToolkit;
+  useAllFiles: boolean;
 
   /**
    * @param gitToolkit - the {@link GitToolkit} instance to use to manage the VCS state
    */
-  constructor(gitToolkit: GitToolkit) {
+  constructor(gitToolkit: GitToolkit, useAllFiles = false) {
     super();
     this.gitToolkit = gitToolkit;
+    this.useAllFiles = useAllFiles;
   }
 
   matchExactPath(filePath: string, to_match: string): boolean {
@@ -35,7 +37,7 @@ export class CurrentCommitFilterStrategy extends FilterStrategy {
    * @returns the filtered list of {@link PackageHook} based on their consistency with the files staged in VCS.
    */
   async filter(hooks: UnprocessedPackageHook[]): Promise<PackageHook[]> {
-    const { staged: stagedFiles } = this.gitToolkit.getVCSState();
+    const stagedFiles = this.useAllFiles ? this.gitToolkit.getAllTrackedFiles() : this.gitToolkit.getVCSState().staged;
 
     const filtered: PackageHook[] = [];
 

--- a/packages/mookme/src/runner/run.ts
+++ b/packages/mookme/src/runner/run.ts
@@ -68,7 +68,7 @@ export class RunRunner {
     this.hooksResolver.setupPATH();
 
     // Load packages hooks to run
-    let hooks = await this.hooksResolver.getPreparedHooks();
+    let hooks = await this.hooksResolver.getPreparedHooks(opts.all);
     hooks = this.hooksResolver.applyOnlyOn(hooks);
     hooks = this.hooksResolver.hydrateArguments(hooks, hookArguments);
 

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -61,6 +61,11 @@ export class GitToolkit {
     };
   }
 
+  getAllTrackedFiles(): string[] {
+    debug(`getAllTrackedFiles called`);
+    return execSync('git ls-tree -r HEAD --name-only').toString().split('\n');
+  }
+
   detectAndProcessModifiedFiles(initialNotStagedFiles: string[], behavior: ADDED_BEHAVIORS): void {
     const notStagedFiles = execSync('echo $(git diff --name-only)')
       .toString()


### PR DESCRIPTION
# Description

This MR introduces a set of basic arguments being available directly within the step command.


### Available arguments

A set of arguments is provided by Mookme, that can be directly used in the hooks command definitions using the following syntax in the step definition:

````json
{
    "command": "run-something {args}" // Will be replaced with the value of `args`
}
````

- `args`

The argument being passed by git to the hook file. See [the Git documentation on the hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) for more details about what it contains depending on the hook type being executed.

- `stagedFiles`

The list of files being matched by the package filtering strategy, and responsible for it being ran in this execution. The files are separated by a blank space (" "). See [the section about how Mookme selects packages to run](https://beta.mookme.org/get-started/#how-will-mookme-decide-which-hooks-to-run) for more details on how the files passed in this are selected.

**The paths are relative from the repository root folder**

- `matchedFiles`

The list of files being matched by the step filtering strategy, and responsible for it being ran in this execution. The files are separated by a blank space (" "). See [the section about how Mookme selects packages to run](https://beta.mookme.org/get-started/#how-will-mookme-decide-which-hooks-to-run) for more details on how the files passed in this are selected.

**The paths are relative from the package folder (eg, the folder where the `.hooks` folder was detected)**

# Examples

Using the following hook definition, eslint will run solely against the ts files being committed:

*File structure*
````
.hooks
  pre-commit.json
src
  some-file.ts -> modified
  some-other-file.ts -> not modified
````

*pre-commit.json*
````json
{
  "steps": [
    {
      "name": "eslint",
      "command": "npx eslint {matchedFiles}",
      "onlyOn": "**/*.ts"
    }
  ]
}
````

*command*
````bash
DEBUG=mookme:*,-mookme:writer,-mookme:ui npx mookme run -t pre-commit
````

<img width="713" alt="image" src="https://user-images.githubusercontent.com/29194680/160129837-47ed17a1-316a-4b5b-a090-45f69d36d749.png">

