### PR TITLE
fix(mookme): fix post-commit hook with previous commit strategy

### DIFF
--- a/packages/mookme/src/loaders/filter-strategies/base-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/base-filter.ts
@@ -1,17 +1,65 @@
+import Debug from 'debug';
+import path from 'path';
 import { PackageHook, UnprocessedPackageHook } from '../../types/hook.types';
+import { GitToolkit } from '../../utils/git';
+
+const debug = Debug('mookme:filtering-strategy');
 
 /**
  * A base class for denoting a strategy used to filter hooks to run
  */
 export abstract class FilterStrategy {
+  gitToolkit: GitToolkit;
+
+  constructor(gitToolkit: GitToolkit) {
+    this.gitToolkit = gitToolkit;
+  }
+
+  abstract geFilesPathList(): string[];
+
+  matchExactPath(filePath: string, to_match: string): boolean {
+    const position = filePath.indexOf(to_match);
+    if (position === -1) {
+      return false;
+    }
+    const remainingPath = filePath.slice(position + to_match.length);
+    return remainingPath.length > 0 ? remainingPath.startsWith('/') : true;
+  }
+
+  /**
+   * Filter a list of packages based on a list of files path relative from the git root directory.
+   * @param hooks - the list of {@link PackageHook} to filter
+   * @returns the filtered list of {@link PackageHook} based on their consistency with the files staged in VCS.
+   */
   async filter(hooks: UnprocessedPackageHook[]): Promise<PackageHook[]> {
-    return hooks.map((hook) => ({
-      ...hook,
-      matchedFiles: [],
-      steps: hook.steps.map((step) => ({
-        ...step,
-        matchedFiles: [],
-      })),
-    }));
+    const filesPathList = this.geFilesPathList();
+
+    const filtered: PackageHook[] = [];
+
+    for (const unprocessedHook of hooks) {
+      // Detect if the current commit includes files concerning this hook
+      const matchedFiles = filesPathList.filter((file) =>
+        this.matchExactPath(path.join(this.gitToolkit.rootDir, file), unprocessedHook.cwd),
+      );
+      if (matchedFiles.length > 0) {
+        debug(`Adding ${unprocessedHook.name} because there are ${matchedFiles.length} files matching it's path`);
+        // Include the matched files in the hook and it's steps
+        filtered.push({
+          ...unprocessedHook,
+          steps: unprocessedHook.steps.map((step) => ({
+            ...step,
+            // Make the step matched paths relative to the cwd of the package they belong to
+            matchedFiles: matchedFiles.map((fPath) =>
+              path.join(this.gitToolkit.rootDir, fPath).replace(`${unprocessedHook.cwd}/`, ''),
+            ),
+          })),
+          matchedFiles,
+        });
+      } else {
+        debug(`Skipping hook ${unprocessedHook.name} because there are no match between it's path and staged files`);
+      }
+    }
+
+    return filtered;
   }
 }

--- a/packages/mookme/src/loaders/filter-strategies/current-commit-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/current-commit-filter.ts
@@ -1,70 +1,21 @@
-import Debug from 'debug';
-import path from 'path';
-import { PackageHook, UnprocessedPackageHook } from '../../types/hook.types';
 import { GitToolkit } from '../../utils/git';
 import { FilterStrategy } from './base-filter';
-
-const debug = Debug('mookme:filtering-strategy');
 
 /**
  * Filter a list of packages based on the VCS state, and the staged files it holds.
  */
 export class CurrentCommitFilterStrategy extends FilterStrategy {
-  gitToolkit: GitToolkit;
   useAllFiles: boolean;
 
   /**
    * @param gitToolkit - the {@link GitToolkit} instance to use to manage the VCS state
    */
   constructor(gitToolkit: GitToolkit, useAllFiles = false) {
-    super();
-    this.gitToolkit = gitToolkit;
+    super(gitToolkit);
     this.useAllFiles = useAllFiles;
   }
 
-  matchExactPath(filePath: string, to_match: string): boolean {
-    const position = filePath.indexOf(to_match);
-    if (position === -1) {
-      return false;
-    }
-    const remainingPath = filePath.slice(position + to_match.length);
-    return remainingPath.length > 0 ? remainingPath.startsWith('/') : true;
-  }
-
-  /**
-   * Filter a list of packages based on the VCS state, and the staged files it holds.
-   * @param hooks - the list of {@link PackageHook} to filter
-   * @returns the filtered list of {@link PackageHook} based on their consistency with the files staged in VCS.
-   */
-  async filter(hooks: UnprocessedPackageHook[]): Promise<PackageHook[]> {
-    const stagedFiles = this.useAllFiles ? this.gitToolkit.getAllTrackedFiles() : this.gitToolkit.getVCSState().staged;
-
-    const filtered: PackageHook[] = [];
-
-    for (const unprocessedHook of hooks) {
-      // Detect if the current commit includes files concerning this hook
-      const matchedFiles = stagedFiles.filter((file) =>
-        this.matchExactPath(path.join(this.gitToolkit.rootDir, file), unprocessedHook.cwd),
-      );
-      if (matchedFiles.length > 0) {
-        debug(`Adding ${unprocessedHook.name} because there are ${matchedFiles.length} files matching it's path`);
-        // Include the matched files in the hook and it's steps
-        filtered.push({
-          ...unprocessedHook,
-          steps: unprocessedHook.steps.map((step) => ({
-            ...step,
-            // Make the step matched paths relative to the cwd of the package they belong to
-            matchedFiles: matchedFiles.map((fPath) =>
-              path.join(this.gitToolkit.rootDir, fPath).replace(`${unprocessedHook.cwd}/`, ''),
-            ),
-          })),
-          matchedFiles,
-        });
-      } else {
-        debug(`Skipping hook ${unprocessedHook.name} because there are no match between it's path and staged files`);
-      }
-    }
-
-    return filtered;
+  geFilesPathList(): string[] {
+    return this.useAllFiles ? this.gitToolkit.getAllTrackedFiles() : this.gitToolkit.getVCSState().staged;
   }
 }

--- a/packages/mookme/src/loaders/filter-strategies/previous-commit-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/previous-commit-filter.ts
@@ -1,11 +1,21 @@
-import { PackageHook } from '../../types/hook.types';
+import { GitToolkit } from '../../utils/git';
 import { FilterStrategy } from './base-filter';
 
 /**
  * A base class for denoting a strategy used to filter hooks to run
  */
 export class PreviousCommitFilterStrategy extends FilterStrategy {
-  async filter(hooks: PackageHook[]): Promise<PackageHook[]> {
-    return hooks;
+  useAllFiles: boolean;
+
+  /**
+   * @param gitToolkit - the {@link GitToolkit} instance to use to manage the VCS state
+   */
+  constructor(gitToolkit: GitToolkit, useAllFiles = false) {
+    super(gitToolkit);
+    this.useAllFiles = useAllFiles;
+  }
+
+  geFilesPathList(): string[] {
+    return this.useAllFiles ? this.gitToolkit.getAllTrackedFiles() : this.gitToolkit.getPreviouslyCommitedFiles();
   }
 }

--- a/packages/mookme/src/loaders/hooks-resolver.ts
+++ b/packages/mookme/src/loaders/hooks-resolver.ts
@@ -300,7 +300,7 @@ export class HooksResolver {
     switch (this.hookType) {
       case HookType.POST_COMMIT:
         debug(`Using strategy PreviousCommitFilterStrategy`);
-        strategy = new PreviousCommitFilterStrategy();
+        strategy = new PreviousCommitFilterStrategy(this.gitToolkit, all);
         break;
       default:
         debug(`Using strategy CurrentCommitFilterStrategy`);

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -53,6 +53,15 @@ export class GitToolkit {
     return stagedFiles;
   }
 
+  getPreviouslyCommitedFiles(nCommitsBeforeHead = 1): string[] {
+    debug(`getPreviouslyCommitedFiles(${nCommitsBeforeHead}) called`);
+    const commitedFiles = execSync(`git diff-tree --no-commit-id --name-only -r HEAD~${nCommitsBeforeHead}`)
+      .toString()
+      .split('\n');
+    debug(`Retrieved the following files commited: ${commitedFiles}`);
+    return commitedFiles;
+  }
+
   getVCSState(): { staged: string[]; notStaged: string[] } {
     debug(`getVCSState called`);
     return {


### PR DESCRIPTION
# Description

I refactored the abstract `FilterStrategy` class, so that it performs the selection of hooks based on a list of files. This part is now standardized, and what changes across strategies is how this list of relative paths is established.

I added a function in the `GitToolkit` class to retrieve the files changed in the previous commit (or n commits before), and I used it the `PreviousFilterStrategy` class.

This fixes #63 :)