### PR TITLE
Feat/two refs aside filter

### DIFF
--- a/packages/mookme/src/commands/inspect.ts
+++ b/packages/mookme/src/commands/inspect.ts
@@ -13,7 +13,7 @@ export function addInspect(program: commander.Command): void {
     .description('Manually test wich packages are discovered and assess if your hooks are properly configured.')
     .action(async (opts) => {
       const git = new GitToolkit();
-      const resolver = new HooksResolver(git, opts.type);
+      const resolver = new HooksResolver(git, opts.type, false);
       const inspect = new InspectRunner(resolver);
       await inspect.run();
     });

--- a/packages/mookme/src/commands/run.ts
+++ b/packages/mookme/src/commands/run.ts
@@ -22,13 +22,15 @@ export function addRun(program: commander.Command): void {
       'A valid git hook type ("pre-commit", "prepare-commit", "commit-msg", "post-commit")',
     )
     .option('-a, --all', 'Run hooks for all packages', '')
+    .option('--from <from>', 'Starting git reference used to evaluate hooks to run', '')
+    .option('--to <to>', 'Ending git reference used to evaluate hooks to run', '')
     .option('--args <args>', 'The arguments being passed to the hooks', '')
     .action(async (opts: RunOptions) => {
       debug('Running run command with options', opts);
       // Initialize the UI
       const ui = new MookmeUI(false);
       const git = new GitToolkit();
-      const resolver = new HooksResolver(git, opts.type);
+      const resolver = new HooksResolver(git, opts.type, opts.all, opts.from, opts.to);
 
       // Load the different config files
       const config = new Config(git.rootDir);

--- a/packages/mookme/src/executor/package-executor.ts
+++ b/packages/mookme/src/executor/package-executor.ts
@@ -6,10 +6,6 @@ import { ExecutionStatus } from '../types/status.types';
 
 export interface PackageExecutorOptions {
   /**
-   * The list of staged files in the current copy
-   */
-  stagedFiles: string[];
-  /**
    * The absolute path pointing towards the root directory
    */
   rootDir: string;
@@ -40,7 +36,6 @@ export class PackageExecutor {
           packagePath: pkg.cwd,
           type: pkg.type,
           venvActivate: pkg.venvActivate,
-          stagedFiles: options.stagedFiles,
           rootDir: options.rootDir,
         }),
     );

--- a/packages/mookme/src/executor/step-executor.ts
+++ b/packages/mookme/src/executor/step-executor.ts
@@ -27,10 +27,6 @@ export interface ExecuteStepOptions {
    * An optional path to a virtualenv to use (only used if type is {@link PackageType.PYTHON})
    */
   venvActivate?: string;
-  /**
-   * The list of files added to the VCS state
-   */
-  stagedFiles: string[];
 }
 
 /**

--- a/packages/mookme/src/loaders/filter-strategies/base-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/base-filter.ts
@@ -10,12 +10,18 @@ const debug = Debug('mookme:filtering-strategy');
  */
 export abstract class FilterStrategy {
   gitToolkit: GitToolkit;
+  useAllFiles: boolean;
 
-  constructor(gitToolkit: GitToolkit) {
+  constructor(gitToolkit: GitToolkit, useAllFiles: boolean) {
     this.gitToolkit = gitToolkit;
+    this.useAllFiles = useAllFiles;
   }
 
-  abstract geFilesPathList(): string[];
+  abstract getFilesPathList(): string[];
+
+  getAllFilesPathList(): string[] {
+    return this.gitToolkit.getAllTrackedFiles();
+  }
 
   matchExactPath(filePath: string, to_match: string): boolean {
     const position = filePath.indexOf(to_match);
@@ -32,7 +38,9 @@ export abstract class FilterStrategy {
    * @returns the filtered list of {@link PackageHook} based on their consistency with the files staged in VCS.
    */
   async filter(hooks: UnprocessedPackageHook[]): Promise<PackageHook[]> {
-    const filesPathList = this.geFilesPathList();
+    debug(this.useAllFiles ? 'Using getAllFilesPathList' : 'Using getFilesPathList');
+    const filesPathList = this.useAllFiles ? this.getAllFilesPathList() : this.getFilesPathList();
+    debug(`Filtering will be performed with list ${filesPathList}`);
 
     const filtered: PackageHook[] = [];
 

--- a/packages/mookme/src/loaders/filter-strategies/current-commit-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/current-commit-filter.ts
@@ -5,17 +5,11 @@ import { FilterStrategy } from './base-filter';
  * Filter a list of packages based on the VCS state, and the staged files it holds.
  */
 export class CurrentCommitFilterStrategy extends FilterStrategy {
-  useAllFiles: boolean;
-
-  /**
-   * @param gitToolkit - the {@link GitToolkit} instance to use to manage the VCS state
-   */
   constructor(gitToolkit: GitToolkit, useAllFiles = false) {
-    super(gitToolkit);
-    this.useAllFiles = useAllFiles;
+    super(gitToolkit, useAllFiles);
   }
 
-  geFilesPathList(): string[] {
-    return this.useAllFiles ? this.gitToolkit.getAllTrackedFiles() : this.gitToolkit.getVCSState().staged;
+  getFilesPathList(): string[] {
+    return this.useAllFiles ? this.gitToolkit.getAllTrackedFiles() : this.gitToolkit.getStagedFiles();
   }
 }

--- a/packages/mookme/src/loaders/filter-strategies/from-to.filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/from-to.filter.ts
@@ -1,0 +1,28 @@
+import { GitToolkit } from '../../utils/git';
+import { FilterStrategy } from './base-filter';
+import Debug from 'debug';
+
+const debug = Debug('mookme:from-to-filter-strategy');
+
+/**
+ * Filter a list of packages based on the VCS state, and the staged files it holds.
+ */
+export class FromToFilterStrategy extends FilterStrategy {
+  from: string;
+  to: string;
+
+  /**
+   * @param from - the Git reference where to keep changed files from
+   * @param to - the Git reference until where to keep changed files
+   */
+  constructor(gitToolkit: GitToolkit, useAllFiles = false, from: string, to: string) {
+    super(gitToolkit, useAllFiles);
+    this.from = from;
+    this.to = to;
+  }
+
+  getFilesPathList(): string[] {
+    debug(`Filtering files between ${this.from} and ${this.to}`);
+    return this.gitToolkit.getFilesChangedBetweenRefs(this.from, this.to);
+  }
+}

--- a/packages/mookme/src/loaders/filter-strategies/previous-commit-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/previous-commit-filter.ts
@@ -5,17 +5,11 @@ import { FilterStrategy } from './base-filter';
  * A base class for denoting a strategy used to filter hooks to run
  */
 export class PreviousCommitFilterStrategy extends FilterStrategy {
-  useAllFiles: boolean;
-
-  /**
-   * @param gitToolkit - the {@link GitToolkit} instance to use to manage the VCS state
-   */
   constructor(gitToolkit: GitToolkit, useAllFiles = false) {
-    super(gitToolkit);
-    this.useAllFiles = useAllFiles;
+    super(gitToolkit, useAllFiles);
   }
 
-  geFilesPathList(): string[] {
+  getFilesPathList(): string[] {
     return this.useAllFiles ? this.gitToolkit.getAllTrackedFiles() : this.gitToolkit.getPreviouslyCommitedFiles();
   }
 }

--- a/packages/mookme/src/loaders/hooks-resolver.ts
+++ b/packages/mookme/src/loaders/hooks-resolver.ts
@@ -9,6 +9,7 @@ import { FilterStrategy } from './filter-strategies/base-filter';
 import { CurrentCommitFilterStrategy } from './filter-strategies/current-commit-filter';
 import { PreviousCommitFilterStrategy } from './filter-strategies/previous-commit-filter';
 import wcmatch from 'wildcard-match';
+import { FromToFilterStrategy } from './filter-strategies/from-to.filter';
 
 const debug = Debug('mookme:hooks-resolver');
 
@@ -19,16 +20,35 @@ export class HooksResolver {
   gitToolkit: GitToolkit;
   root: string;
   hookType: string;
+  strategy: FilterStrategy;
 
   /**
    * A class defining several utilitaries used to load and prepare packages hooks to be executed
    *
    * @param gitToolkit - the {@link GitToolkit} instance to use to manage the VCS state
    */
-  constructor(gitToolkit: GitToolkit, hookType: HookType) {
+  constructor(gitToolkit: GitToolkit, hookType: HookType, useAllFiles: boolean, from?: string, to?: string) {
     this.gitToolkit = gitToolkit;
     this.root = gitToolkit.rootDir;
     this.hookType = hookType;
+
+    // Perform filtering based on a selected strategy
+    // @TODO: Enhance this part by adding multiple strategies, and rule to select them
+    if (from && to) {
+      debug(`Using strategy FromToFilterStrategy from ${from} to ${to}`);
+      this.strategy = new FromToFilterStrategy(this.gitToolkit, useAllFiles, from, to);
+    } else {
+      switch (this.hookType) {
+        case HookType.POST_COMMIT:
+          debug(`Using strategy PreviousCommitFilterStrategy`);
+          this.strategy = new PreviousCommitFilterStrategy(this.gitToolkit, useAllFiles);
+          break;
+        default:
+          debug(`Using strategy CurrentCommitFilterStrategy`);
+          this.strategy = new CurrentCommitFilterStrategy(this.gitToolkit, useAllFiles);
+          break;
+      }
+    }
   }
 
   /**
@@ -273,7 +293,7 @@ export class HooksResolver {
    * A wrapper for executing the packages-retrieval flow.
    * @returns the list of prepared packages to hook, filtered based on the VCS state and including interpolated shared steps.
    */
-  async getPreparedHooks(all: boolean): Promise<PackageHook[]> {
+  async getPreparedHooks(): Promise<PackageHook[]> {
     // Retrieve every hookable package
     const allPackages: string[] = this.extractPackagesPaths();
     debug(`Identified the following packages: ${allPackages}`);
@@ -293,23 +313,7 @@ export class HooksResolver {
     unprocessedHooks = this.interpolateSharedSteps(unprocessedHooks);
     debug(`Done loading ${unprocessedHooks.length} hooks`);
 
-    // Perform filtering based on a selected strategy
-    // @TODO: Enhance this part by adding multiple strategies, and rule to select them
-    let strategy: FilterStrategy;
-
-    switch (this.hookType) {
-      case HookType.POST_COMMIT:
-        debug(`Using strategy PreviousCommitFilterStrategy`);
-        strategy = new PreviousCommitFilterStrategy(this.gitToolkit, all);
-        break;
-      default:
-        debug(`Using strategy CurrentCommitFilterStrategy`);
-        strategy = new CurrentCommitFilterStrategy(this.gitToolkit, all);
-        break;
-    }
-
-    const hooks: PackageHook[] = await strategy.filter(unprocessedHooks);
-
+    const hooks: PackageHook[] = await this.strategy.filter(unprocessedHooks);
     return hooks;
   }
 }

--- a/packages/mookme/src/runner/run.ts
+++ b/packages/mookme/src/runner/run.ts
@@ -23,6 +23,14 @@ export interface RunOptions {
    * A boolean parameter to detect if the whole hook suite should be ran, regardless of the VCS state
    */
   all: boolean;
+  /**
+   * A boolean parameter to detect if the whole hook suite should be ran, regardless of the VCS state
+   */
+  from: string;
+  /**
+   * A boolean parameter to detect if the whole hook suite should be ran, regardless of the VCS state
+   */
+  to: string;
 }
 
 /**
@@ -59,7 +67,7 @@ export class RunRunner {
     this.ui.start();
 
     // Load the VCS state
-    const { staged: initialStagedFiles, notStaged: initialNotStagedFiles } = this.gitToolkit.getVCSState();
+    const initialNotStagedFiles = this.gitToolkit.getNotStagedFiles();
 
     // Retrieve mookme command options
     const { args: hookArguments } = opts;
@@ -68,7 +76,7 @@ export class RunRunner {
     this.hooksResolver.setupPATH();
 
     // Load packages hooks to run
-    let hooks = await this.hooksResolver.getPreparedHooks(opts.all);
+    let hooks = await this.hooksResolver.getPreparedHooks();
     hooks = this.hooksResolver.applyOnlyOn(hooks);
     hooks = this.hooksResolver.hydrateArguments(hooks, hookArguments);
 
@@ -76,7 +84,6 @@ export class RunRunner {
     const packageExecutors = hooks.map(
       (pkg) =>
         new PackageExecutor(pkg, {
-          stagedFiles: initialStagedFiles,
           rootDir: this.gitToolkit.rootDir,
         }),
     );

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -62,6 +62,17 @@ export class GitToolkit {
     return commitedFiles;
   }
 
+  getFilesChangedBetweenRefs(from: string, to: string): string[] {
+    debug(`getFilesChangedBetweenRefs(${from}, ${to}) called`);
+    const changedFiles = execSync(`echo $(git diff ${from} ${to} --name-only)`)
+      .toString()
+      .split(' ')
+      .map((pth) => pth.replace('\n', ''));
+
+    debug(`Retrieved the following files commited: ${changedFiles}`);
+    return changedFiles;
+  }
+
   getVCSState(): { staged: string[]; notStaged: string[] } {
     debug(`getVCSState called`);
     return {
@@ -72,7 +83,7 @@ export class GitToolkit {
 
   getAllTrackedFiles(): string[] {
     debug(`getAllTrackedFiles called`);
-    return execSync('git ls-tree -r HEAD --name-only').toString().split('\n');
+    return execSync('git ls-tree -r HEAD --name-only', { cwd: this.rootDir }).toString().split('\n');
   }
 
   detectAndProcessModifiedFiles(initialNotStagedFiles: string[], behavior: ADDED_BEHAVIORS): void {


### PR DESCRIPTION
# Description

I added the from/to command line arguments for selecting two commits or git reference to select changed files between. They are then used to infer what hooks to run.

A few things to know:

- from/to are meant to be used with direct invocations of the CLI, not in the step JSON files
- if not set together (eg just from or just to), from/to are ignored, and the strategy is defined based on the hook type
- if set together, the strategy defined by the hook type is ignored and the `FromToFilterStrategy` is used.

It resolves #65

## Usage

```
npx mookme run -t pre-commit -f HEAD~6 -t HEAD~1
```

# TODOs

[] Add documentation once we settled on the feature