### PR TITLE
Make Mookme work on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto

--- a/packages/mookme/package-lock.json
+++ b/packages/mookme/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.2.0-beta.2",
       "license": "MIT",
       "dependencies": {
-        "@types/node": "^15.0.2",
         "chalk": "^4.1.1",
         "commander": "^7.2.0",
         "debug": "^4.3.4",
@@ -25,6 +24,7 @@
         "@tsconfig/node10": "^1.0.7",
         "@types/debug": "^4.1.7",
         "@types/inquirer": "^7.3.1",
+        "@types/node": "^15.0.2",
         "@typescript-eslint/eslint-plugin": "4.22.1",
         "@typescript-eslint/parser": "4.22.1",
         "eslint": "^7.26.0",
@@ -33,6 +33,7 @@
         "eslint-plugin-prettier": "3.4.0",
         "eslint-plugin-tsdoc": "^0.2.14",
         "prettier": "2.3.0",
+        "rimraf": "^3.0.2",
         "semantic-release": "^18.0.0",
         "typescript": "^4.2.4"
       }
@@ -624,7 +625,8 @@
     "node_modules/@types/node": {
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -9093,7 +9095,8 @@
     "@types/node": {
       "version": "15.14.9",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
-      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A=="
+      "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/packages/mookme/package.json
+++ b/packages/mookme/package.json
@@ -16,9 +16,9 @@
     "dev": "tsc -w",
     "test": "echo \"Error: no test specified\" && exit 1",
     "prettier": "prettier -c src/**/*.ts",
-    "prettier:fix": "prettier --write 'src/**/*.ts'",
-    "eslint": "eslint 'src/**/*.ts'",
-    "eslint:fix": "eslint --fix 'src/**/*.ts'",
+    "prettier:fix": "prettier --write src/**/*.ts",
+    "eslint": "eslint src/**/*.ts",
+    "eslint:fix": "eslint --fix src/**/*.ts",
     "prepublishOnly": "npm run build"
   },
   "repository": {

--- a/packages/mookme/package.json
+++ b/packages/mookme/package.json
@@ -11,7 +11,7 @@
     "dist/**/*.js"
   ],
   "scripts": {
-    "prebuild": "rm -f ./.tmp/ts-build-infos.json && rm -rf dist",
+    "prebuild": "rimraf -f ./.tmp/ts-build-infos.json && rimraf -rf dist",
     "build": "tsc",
     "dev": "tsc -w",
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -58,6 +58,7 @@
     "eslint-plugin-prettier": "3.4.0",
     "eslint-plugin-tsdoc": "^0.2.14",
     "prettier": "2.3.0",
+    "rimraf": "^3.0.2",
     "semantic-release": "^18.0.0",
     "typescript": "^4.2.4"
   },

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -125,15 +125,13 @@ export class GitToolkit {
       if (fs.existsSync(`${gitFolderPath}/hooks/${type}`)) {
         const hook = fs.readFileSync(`${gitFolderPath}/hooks/${type}`).toString();
         if (!hook.includes(mookmeCmd)) {
-          fs.appendFileSync(`${gitFolderPath}/hooks/${type}`, `\n${mookmeCmd}`, { flag: 'a+' });
-          execSync(`chmod +x ${gitFolderPath}/hooks/${type}`);
+          fs.appendFileSync(`${gitFolderPath}/hooks/${type}`, `\n${mookmeCmd}`, { flag: 'a+', mode: 0o0755 });
         } else {
           logger.log(`Hook ${type} is already declared, skipping...`);
         }
       } else {
         logger.warning(`Hook ${type} does not exist, creating file...`);
-        fs.appendFileSync(`${gitFolderPath}/hooks/${type}`, `#!/bin/bash\n${mookmeCmd}`, { flag: 'a+' });
-        execSync(`chmod +x ${gitFolderPath}/hooks/${type}`);
+        fs.appendFileSync(`${gitFolderPath}/hooks/${type}`, `#!/bin/bash\n${mookmeCmd}`, { flag: 'a+', mode: 0o0755 });
       }
     });
   }


### PR DESCRIPTION
This pr addresses issues causing Mookme to fail on Windows.
It mainly removes Linux only commands.

It will close #83, #84 