### PR TITLE
Fix/pre push strategy

### DIFF
--- a/packages/mookme/src/loaders/filter-strategies/not-pushed-files-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/not-pushed-files-filter.ts
@@ -5,13 +5,14 @@ import Debug from 'debug';
 
 const debug = Debug('mookme:not-pushed-files-filter-strategy');
 
-export class NotPushedFilesFilter extends FilterStrategy {
+export class NotPushedFilesFilterStrategy extends FilterStrategy {
   constructor(gitToolkit: GitToolkit, useAllFiles = false) {
     super(gitToolkit, useAllFiles);
   }
 
   getFilesPathList(): string[] {
-    const branchName = this.gitToolkit.getCurrentBranchName()
-    return this.useAllFiles ? this.gitToolkit.getAllTrackedFiles() : this.gitToolkit.getFilesChangedBetweenRefs('HEAD', `origin/HEAD`);
+    const files = this.useAllFiles ? this.gitToolkit.getAllTrackedFiles() : this.gitToolkit.getFilesToPush();
+    debug(`Using files ${files.join(', ')} for pre-push stategy`);
+    return files;
   }
 }

--- a/packages/mookme/src/loaders/filter-strategies/not-pushed-files-filter.ts
+++ b/packages/mookme/src/loaders/filter-strategies/not-pushed-files-filter.ts
@@ -1,0 +1,17 @@
+import { GitToolkit } from '../../utils/git';
+import { FilterStrategy } from './base-filter';
+
+import Debug from 'debug';
+
+const debug = Debug('mookme:not-pushed-files-filter-strategy');
+
+export class NotPushedFilesFilter extends FilterStrategy {
+  constructor(gitToolkit: GitToolkit, useAllFiles = false) {
+    super(gitToolkit, useAllFiles);
+  }
+
+  getFilesPathList(): string[] {
+    const branchName = this.gitToolkit.getCurrentBranchName()
+    return this.useAllFiles ? this.gitToolkit.getAllTrackedFiles() : this.gitToolkit.getFilesChangedBetweenRefs('HEAD', `origin/HEAD`);
+  }
+}

--- a/packages/mookme/src/loaders/hooks-resolver.ts
+++ b/packages/mookme/src/loaders/hooks-resolver.ts
@@ -10,6 +10,7 @@ import { CurrentCommitFilterStrategy } from './filter-strategies/current-commit-
 import { PreviousCommitFilterStrategy } from './filter-strategies/previous-commit-filter';
 import wcmatch from 'wildcard-match';
 import { FromToFilterStrategy } from './filter-strategies/from-to.filter';
+import { NotPushedFilesFilterStrategy } from './filter-strategies/not-pushed-files-filter';
 
 const debug = Debug('mookme:hooks-resolver');
 
@@ -53,6 +54,10 @@ export class HooksResolver {
       this.strategy = new FromToFilterStrategy(this.gitToolkit, useAllFiles, from, to);
     } else {
       switch (this.hookType) {
+        case HookType.PRE_PUSH:
+          debug(`Using strategy NotPushedFilesFilter`);
+          this.strategy = new NotPushedFilesFilterStrategy(this.gitToolkit, useAllFiles);
+          break;
         case HookType.POST_COMMIT:
           debug(`Using strategy PreviousCommitFilterStrategy`);
           this.strategy = new PreviousCommitFilterStrategy(this.gitToolkit, useAllFiles);

--- a/packages/mookme/src/runner/run.ts
+++ b/packages/mookme/src/runner/run.ts
@@ -78,6 +78,7 @@ export class RunRunner {
     // Load packages hooks to run
     let hooks = await this.hooksResolver.getPreparedHooks();
     hooks = this.hooksResolver.applyOnlyOn(hooks);
+
     hooks = this.hooksResolver.hydrateArguments(hooks, hookArguments);
 
     // Instanciate the package executors

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -83,7 +83,13 @@ export class GitToolkit {
 
   getFilesToPush(): string[] {
     debug(`getFilesToPush called`);
-    const commits = execSync('git rev-list @{push}..', { cwd: this.rootDir }).toString().split('\n').filter(Boolean);
+    let commits: string[] = [];
+    try {
+      commits = execSync('git rev-list @{push}..', { cwd: this.rootDir }).toString().split('\n').filter(Boolean);
+    } catch (e) {
+      logger.warning('Failed to retrieve the list of commits to push.');
+      debug(e);
+    }
     if (commits.length === 0) return [];
     return this.getFilesChangedBetweenRefs(commits[commits.length - 1], commits[0]);
   }

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -65,7 +65,7 @@ export class GitToolkit {
   }
 
   getCurrentBranchName(): string {
-    return execSync('git rev-parse --abbrev-ref HEAD').toString()
+    return execSync('git rev-parse --abbrev-ref HEAD').toString();
   }
 
   getVCSState(): { staged: string[]; notStaged: string[] } {
@@ -79,6 +79,13 @@ export class GitToolkit {
   getAllTrackedFiles(): string[] {
     debug(`getAllTrackedFiles called`);
     return execSync('git ls-tree -r HEAD --name-only', { cwd: this.rootDir }).toString().split('\n');
+  }
+
+  getFilesToPush(): string[] {
+    debug(`getFilesToPush called`);
+    const commits = execSync('git rev-list @{push}..', { cwd: this.rootDir }).toString().split('\n').filter(Boolean);
+    if (commits.length === 0) return [];
+    return this.getFilesChangedBetweenRefs(commits[commits.length - 1], commits[0]);
   }
 
   detectAndProcessModifiedFiles(initialNotStagedFiles: string[], behavior: ADDED_BEHAVIORS): void {

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -64,6 +64,10 @@ export class GitToolkit {
     return changedFiles;
   }
 
+  getCurrentBranchName(): string {
+    return execSync('git rev-parse --abbrev-ref HEAD').toString()
+  }
+
   getVCSState(): { staged: string[]; notStaged: string[] } {
     debug(`getVCSState called`);
     return {


### PR DESCRIPTION
# Description

This mr brings basic support for the `pre-push` strategy. The list of files to use to select hooks to run is computed with the command `git rev-list @{push}..` which returns a list of commits. This list is then used to retrieve the list of changed files.

# Caveats

The command will surely fail when there are no remote origins. That's why I added a `try/catch` statement. I'll try to come up with something less flaky.

This should close https://github.com/Escape-Technologies/mookme/issues/81