### PR TITLE
Add condaEnv variable that allow to use a conda environment for commands

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           persist-credentials: false
-          token: ${{ secrets.ACCESS_TOKEN }}
 
 
       - name: Cache node modules
@@ -38,7 +37,6 @@ jobs:
 
       - name: Publish
         env:
-          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd packages/mookme

--- a/packages/docs/references/README.md
+++ b/packages/docs/references/README.md
@@ -107,6 +107,11 @@ A flag used mainly to tell `mookme` this is a python hook, and might need a virt
 
 A path to a `<venv>/bin/activate` script to execute before the command if the hook type is `python`
 
+- `condaEnv`
+
+A conda environment name to use for the execution of the command
+
+
 ### Available arguments
 
 A set of arguments is provided by Mookme, that can be directly used in the hooks command definitions using the following syntax in the step definition:

--- a/packages/mookme/src/executor/package-executor.ts
+++ b/packages/mookme/src/executor/package-executor.ts
@@ -36,6 +36,7 @@ export class PackageExecutor {
           packagePath: pkg.cwd,
           type: pkg.type,
           venvActivate: pkg.venvActivate,
+          condaEnv: pkg.condaEnv,
           rootDir: options.rootDir,
         }),
     );

--- a/packages/mookme/src/executor/step-executor.ts
+++ b/packages/mookme/src/executor/step-executor.ts
@@ -27,6 +27,10 @@ export interface ExecuteStepOptions {
    * An optional path to a virtualenv to use (only used if type is {@link PackageType.PYTHON})
    */
   venvActivate?: string;
+  /**
+   * An optional conda env to use
+   */
+  condaEnv?: string;
 }
 
 /**
@@ -89,9 +93,10 @@ export class StepExecutor {
    */
   computeExecutedCommand(): string {
     // Add eventual virtual env to activate before the command
-    const { type, venvActivate } = this.options;
+    const { type, venvActivate, condaEnv } = this.options;
     const { command } = this.step;
-    const execute = type === 'python' && venvActivate ? `source ${venvActivate} && ${command} && deactivate` : command;
+    const env_execute = type === 'python' && venvActivate ? `source ${venvActivate} && ${command} && deactivate` : command;
+    const execute = condaEnv ? `conda run -n ${condaEnv} && ${env_execute}` : env_execute;
 
     return execute;
   }

--- a/packages/mookme/src/loaders/hooks-resolver.ts
+++ b/packages/mookme/src/loaders/hooks-resolver.ts
@@ -135,6 +135,7 @@ export class HooksResolver {
       cwd: packagePath,
       type: hooksDefinition.type,
       venvActivate: hooksDefinition.venvActivate,
+      condaEnv: hooksDefinition.condaEnv,
       steps: hooksDefinition.steps,
     };
 

--- a/packages/mookme/src/types/hook.types.ts
+++ b/packages/mookme/src/types/hook.types.ts
@@ -58,6 +58,11 @@ export interface UnprocessedPackageHook {
    * A boolean denoting whether a virtualenv is started of not for this hook (eg for Python)
    */
   venvActivate?: string;
+  /**
+   * The conda environment we want to use to start this hook. Optional
+   */
+  condaEnv?: string;
+
 }
 
 export interface PackageHook extends UnprocessedPackageHook {


### PR DESCRIPTION
Hey,

As I said in the discussions, I needed to run my linter through a conda environment. So I decided to make it possible by adding a new variable "condaEnv"