### PR TITLE
Add condaEnv variable that allow to use a conda environment for commands

### DIFF
--- a/packages/mookme/src/executor/package-executor.ts
+++ b/packages/mookme/src/executor/package-executor.ts
@@ -36,6 +36,7 @@ export class PackageExecutor {
           packagePath: pkg.cwd,
           type: pkg.type,
           venvActivate: pkg.venvActivate,
+          condaEnv: pkg.condaEnv,
           rootDir: options.rootDir,
         }),
     );

--- a/packages/mookme/src/executor/step-executor.ts
+++ b/packages/mookme/src/executor/step-executor.ts
@@ -27,6 +27,10 @@ export interface ExecuteStepOptions {
    * An optional path to a virtualenv to use (only used if type is {@link PackageType.PYTHON})
    */
   venvActivate?: string;
+  /**
+   * An optional conda env to use
+   */
+  condaEnv?: string;
 }
 
 /**
@@ -89,9 +93,11 @@ export class StepExecutor {
    */
   computeExecutedCommand(): string {
     // Add eventual virtual env to activate before the command
-    const { type, venvActivate } = this.options;
+    const { type, venvActivate, condaEnv } = this.options;
     const { command } = this.step;
-    const execute = type === 'python' && venvActivate ? `source ${venvActivate} && ${command} && deactivate` : command;
+    const env_execute =
+      type === 'python' && venvActivate ? `source ${venvActivate} && ${command} && deactivate` : command;
+    const execute = condaEnv ? `conda run -n ${condaEnv} ""${env_execute}""` : env_execute;
 
     return execute;
   }

--- a/packages/mookme/src/loaders/hooks-resolver.ts
+++ b/packages/mookme/src/loaders/hooks-resolver.ts
@@ -135,6 +135,7 @@ export class HooksResolver {
       cwd: packagePath,
       type: hooksDefinition.type,
       venvActivate: hooksDefinition.venvActivate,
+      condaEnv: hooksDefinition.condaEnv,
       steps: hooksDefinition.steps,
     };
 

--- a/packages/mookme/src/types/hook.types.ts
+++ b/packages/mookme/src/types/hook.types.ts
@@ -58,6 +58,10 @@ export interface UnprocessedPackageHook {
    * A boolean denoting whether a virtualenv is started of not for this hook (eg for Python)
    */
   venvActivate?: string;
+  /**
+   * The conda environment we want to use to start this hook. Optional
+   */
+  condaEnv?: string;
 }
 
 export interface PackageHook extends UnprocessedPackageHook {


### PR DESCRIPTION
Hey,

As I said in the discussions, I needed to run my linter through a conda environment. So I decided to make it possible by adding a new variable "condaEnv"