### PR TITLE
fix/typos

### DIFF
--- a/packages/docs/get-started/README.md
+++ b/packages/docs/get-started/README.md
@@ -21,7 +21,7 @@ Hence it only requires a very minimal configuration, as most of this is defined 
 **Case 1 : You are the first to configure `Mookme` on your project**
 
 ```bash
-npx mookme init
+npx @escape.tech/mookme init
 ```
 
 This will display a prompter to let you define how you want the hooks to behave when a file is changed during commit hooks, write the corresponding documentation in your `package.json`, and write your `.git/hooks` scripts.
@@ -35,7 +35,7 @@ Every step of this process is clearly shown and nothing will be written without 
 This will only write your `.git/hooks` scripts.
 
 ```bash
-npx mookme init --only-hook
+npx @escape.tech/mookme init --only-hook
 ```
 
 ## Writing your hooks
@@ -61,7 +61,7 @@ Hooks are written in a folder `.hooks` located at the root of your project and a
 |- packages
 |  |- package A
 |  |  |- .hooks # will be executed if you commit changes on package A
-|  |  |  |- pre-commit.json 
+|  |  |  |- pre-commit.json
 |  |  |  |- post-commit.json
 |  |- package A
 |  |  |- .hooks # will be executed if you commit changes on package B

--- a/packages/mookme/src/runner/init.ts
+++ b/packages/mookme/src/runner/init.ts
@@ -71,7 +71,7 @@ export class InitRunner {
     logger.log(JSON.stringify(mookMeConfig, null, 2));
 
     logger.info('');
-    logger.info('The follwowing git hooks will be created:');
+    logger.info('The following git hooks will be created:');
     hookTypes.forEach((t) => logger.log(`${root}/.git/hooks/${t}`));
 
     logger.info('');

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -124,7 +124,7 @@ export class GitToolkit {
 
     hookTypes.forEach((type) => {
       logger.info(`- ${gitFolderPath}/hooks/${type}`);
-      const mookmeCmd = `npx mookme run --type ${type} --args "$1"`;
+      const mookmeCmd = `npx @escape.tech/mookme run --type ${type} --args "$1"`;
       if (fs.existsSync(`${gitFolderPath}/hooks/${type}`)) {
         const hook = fs.readFileSync(`${gitFolderPath}/hooks/${type}`).toString();
         if (!hook.includes(mookmeCmd)) {


### PR DESCRIPTION
a couple of typo fixes and one small change I found I needed to run the hooks locally: 
1. update the README where I found the usage was inconsistent
2. fix a typo I encountered when running the hook script
3. change the hook code from `npx mookme run --type ${type} --args "$1"` to `npx @escape.tech/mookme run --type ${type} --args "$1"`. I found the hooks generated previously with the original command did not run on my machine without updating the line above. 