### PR TITLE
Feat/add type to init

### DIFF
--- a/packages/mookme/src/commands/init.ts
+++ b/packages/mookme/src/commands/init.ts
@@ -12,7 +12,10 @@ export function addInit(program: commander.Command): void {
     .option('--added-behaviour <added-behaviour>', 'Provide added behaviour and skip the associated prompter')
     .option('--skip-types-selection', 'Skip hook types selection')
     .option('--yes', 'Skip confirmation prompter')
-    .option('-t, --type <type>', 'A valid git hook type ("pre-commit", "prepare-commit", "commit-msg", "post-commit")')
+    .option(
+      '-t, --types <types...>',
+      'A list of valid git hooks ("pre-commit", "prepare-commit", "commit-msg", "post-commit")',
+    )
     .action(async (opts: InitOptions) => {
       debug('Running init command with options', opts);
       const git = new GitToolkit();

--- a/packages/mookme/src/commands/init.ts
+++ b/packages/mookme/src/commands/init.ts
@@ -12,6 +12,7 @@ export function addInit(program: commander.Command): void {
     .option('--added-behaviour <added-behaviour>', 'Provide added behaviour and skip the associated prompter')
     .option('--skip-types-selection', 'Skip hook types selection')
     .option('--yes', 'Skip confirmation prompter')
+    .option('-t, --type <type>', 'A valid git hook type ("pre-commit", "prepare-commit", "commit-msg", "post-commit")')
     .action(async (opts: InitOptions) => {
       debug('Running init command with options', opts);
       const git = new GitToolkit();

--- a/packages/mookme/src/prompts/init.ts
+++ b/packages/mookme/src/prompts/init.ts
@@ -12,15 +12,16 @@ export const choiceQuestion = (name: string, message: string, choices: string[])
   pageSize: process.stdout.rows / 2,
 });
 
-export async function selectHookTypes(skip = false, typeToHook?: HookType): Promise<HookType[]> {
+// @todo(lecanu.maxence@gmail.com): standardize arguments of this function as a unique argument being an array of types
+export async function selectHookTypes(skip = false, hookCollection?: HookType[]): Promise<HookType[]> {
   let typesToHook: HookType[];
 
   if (skip) {
     // If skip is provided, skip everything and return the hook types
     typesToHook = hookTypes;
-  } else if (typeToHook) {
-    // If skip is not provided, but a type is provided, return the type
-    typesToHook = [typeToHook];
+  } else if (hookCollection) {
+    // If skip is not provided, but types are provided, return the types
+    typesToHook = hookCollection;
   } else {
     // Prompt the user for the hook types
     const { types } = (await inquirer.prompt([

--- a/packages/mookme/src/prompts/init.ts
+++ b/packages/mookme/src/prompts/init.ts
@@ -12,16 +12,23 @@ export const choiceQuestion = (name: string, message: string, choices: string[])
   pageSize: process.stdout.rows / 2,
 });
 
-export async function selectHookTypes(skip = false): Promise<HookType[]> {
+export async function selectHookTypes(skip = false, typeToHook?: HookType): Promise<HookType[]> {
   let typesToHook: HookType[];
+
   if (skip) {
+    // If skip is provided, skip everything and return the hook types
     typesToHook = hookTypes;
+  } else if (typeToHook) {
+    // If skip is not provided, but a type is provided, return the type
+    typesToHook = [typeToHook];
   } else {
+    // Prompt the user for the hook types
     const { types } = (await inquirer.prompt([
       choiceQuestion('types', 'Select git events to hook :\n', hookTypes),
     ])) as { types: HookType[] };
     typesToHook = types;
   }
+
   return typesToHook;
 }
 

--- a/packages/mookme/src/runner/init.ts
+++ b/packages/mookme/src/runner/init.ts
@@ -36,9 +36,9 @@ export interface InitOptions {
    */
   yes?: boolean;
   /**
-   * The hook type executed. See {@link HookType}
+   * The hook types executed. See {@link HookType}
    */
-  type?: HookType;
+  types?: HookType[];
 }
 
 export class InitRunner {
@@ -52,7 +52,7 @@ export class InitRunner {
     const root = this.gitToolkit.rootDir;
 
     if (opts.onlyHook) {
-      const hookTypes = await selectHookTypes(opts.skipTypesSelection, opts.type);
+      const hookTypes = await selectHookTypes(opts.skipTypesSelection, opts.types);
       this.gitToolkit.writeGitHooksFiles(hookTypes);
       process.exit(0);
     }
@@ -69,7 +69,7 @@ export class InitRunner {
       addedBehavior,
     };
 
-    const hookTypes = await selectHookTypes(opts.skipTypesSelection, opts.type);
+    const hookTypes = await selectHookTypes(opts.skipTypesSelection, opts.types);
 
     clear();
     logger.info(`The following configuration will be written into \`${root}/.mookme.json\`:`);

--- a/packages/mookme/src/runner/init.ts
+++ b/packages/mookme/src/runner/init.ts
@@ -5,6 +5,7 @@ import { ADDED_BEHAVIORS } from '../config/types';
 import { addedBehaviorQuestion, selectHookTypes } from '../prompts/init';
 import { GitToolkit } from '../utils/git';
 import logger from '../utils/logger';
+import { HookType } from '../types/hook.types';
 
 const clear = () => process.stdout.write('\x1Bc');
 
@@ -34,6 +35,10 @@ export interface InitOptions {
    * Skip confirmation prompter
    */
   yes?: boolean;
+  /**
+   * The hook type executed. See {@link HookType}
+   */
+  type?: HookType;
 }
 
 export class InitRunner {
@@ -47,7 +52,7 @@ export class InitRunner {
     const root = this.gitToolkit.rootDir;
 
     if (opts.onlyHook) {
-      const hookTypes = await selectHookTypes(opts.skipTypesSelection);
+      const hookTypes = await selectHookTypes(opts.skipTypesSelection, opts.type);
       this.gitToolkit.writeGitHooksFiles(hookTypes);
       process.exit(0);
     }
@@ -64,7 +69,7 @@ export class InitRunner {
       addedBehavior,
     };
 
-    const hookTypes = await selectHookTypes(opts.skipTypesSelection);
+    const hookTypes = await selectHookTypes(opts.skipTypesSelection, opts.type);
 
     clear();
     logger.info(`The following configuration will be written into \`${root}/.mookme.json\`:`);


### PR DESCRIPTION
Use Case:

I would like the ability to add a [prepare](https://docs.npmjs.com/cli/v10/using-npm/scripts#prepare-and-prepublish) step to my package.json like [Husky](https://github.com/typicode/husky) has in their library so on every install, we reinforce that hooks are present. 

While the current `--skip-types-selection` will enable this for ALL types, my repo currently only leverages the `pre-commit` hook, so I'd like to be able to specify that in the `prepare` statement, so everyone gets a pre-commit hook who installs the repo. 