### PR TITLE
Fix not-pushed-files-filter strategy

### DIFF
--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -85,7 +85,7 @@ export class GitToolkit {
     debug(`getFilesToPush called`);
     let commits: string[] = [];
     try {
-      commits = execSync('git rev-list @{push}..', { cwd: this.rootDir }).toString().split('\n').filter(Boolean);
+      commits = execSync('git rev-list @{push}^..', { cwd: this.rootDir }).toString().split('\n').filter(Boolean);
     } catch (e) {
       logger.warning('Failed to retrieve the list of commits to push.');
       debug(e);


### PR DESCRIPTION
Fixes: https://github.com/Escape-Technologies/mookme/issues/111

I noticed that with a single unpushed commit `git rev-list @{push}..` returns only a single commit

```
git rev-list @{push}..
af5d67bfaf2331f360e6a85c2c4e8ea814c3d5dd
```

and `this.getFilesChangedBetweenRefs(commits[commits.length - 1], commits[0])` obviously returns no diff, resulting in the pre-push hook being skipped.

Using `git rev-list @{push}^..` returns a list including the `@{push}` reference:

```
git rev-list @{push}^..
af5d67bfaf2331f360e6a85c2c4e8ea814c3d5dd
5afce4d9b54ba19fdfe390e8af500e803cd786c0
```

The diff properly returns the changed files and the pre-push hook is run