### PR TITLE
fix: add and commit behavior for files with symbols and spaces

### DIFF
--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -103,7 +103,7 @@ export class GitToolkit {
           logger.warning('Files were changed during hook execution !');
           logger.info('Following the defined behavior : Add and continue.');
           for (const file of changedFiles) {
-            execSync(`git add ${this.rootDir}/${file}`);
+            execSync(`git add "${this.rootDir}/${file}"`);
           }
           break;
         case ADDED_BEHAVIORS.EXIT:


### PR DESCRIPTION
The path to the file names are enclosed in quotes so that it can add files with symbols and spaces.

resolves #121 