### PR TITLE
fix: add support for worktree

### DIFF
--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { execSync } from 'child_process';
+import path from 'path';
 import { HookType } from '../types/hook.types';
 import { ADDED_BEHAVIORS } from '../config/types';
 import logger from './logger';
@@ -31,6 +32,16 @@ export class GitToolkit {
       process.exit(0);
     }
     this.rootDir = rootDir;
+  }
+
+  getGitFolderPath(): string {
+    const gitFolderPath = execSync('git rev-parse --git-common-dir').toString().trim()
+
+    if (!path.isAbsolute(gitFolderPath)) {
+      return path.resolve(gitFolderPath);
+    }
+
+    return gitFolderPath;
   }
 
   getNotStagedFiles(): string[] {
@@ -115,7 +126,7 @@ export class GitToolkit {
   }
 
   writeGitHooksFiles(hookTypes: HookType[]): void {
-    const gitFolderPath = `${this.rootDir}/.git`;
+    const gitFolderPath = this.getGitFolderPath();
     if (!fs.existsSync(`${gitFolderPath}/hooks`)) {
       fs.mkdirSync(`${gitFolderPath}/hooks`);
     }


### PR DESCRIPTION
When working with [git worktree](https://git-scm.com/docs/git-worktree), the Git folder path is different between worktrees and the main tree.

Main working dir:
```sh
$ git rev-parse --git-common-dir
.git
```

Worktree:
```sh
git rev-parse --git-common-dir
/Users/some_user/projects/mookme
```

This PR intends to add support for git worktree by getting the git directory from the `git rev-parse --git-common-dir` command.

When dealing with the main working directory, it is important to handle the absolute path.

Close #127