### PR TITLE
Basic filtering of deleted files

### DIFF
--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -49,7 +49,7 @@ export class GitToolkit {
 
   getPreviouslyCommitedFiles(nCommitsBeforeHead = 1): string[] {
     debug(`getPreviouslyCommitedFiles(${nCommitsBeforeHead}) called`);
-    const commitedFiles = execSync(`git diff-tree --diff-filter=d --no-commit-id --name-only -r HEAD~${nCommitsBeforeHead}`)
+    const commitedFiles = execSync(`git diff-tree --no-commit-id --name-only -r HEAD~${nCommitsBeforeHead}`)
       .toString()
       .split('\n');
     debug(`Retrieved the following files commited: ${commitedFiles}`);

--- a/packages/mookme/src/utils/git.ts
+++ b/packages/mookme/src/utils/git.ts
@@ -35,21 +35,21 @@ export class GitToolkit {
 
   getNotStagedFiles(): string[] {
     debug(`getNotStagedFiles called`);
-    const notStagedFiles = execSync('git diff --name-only').toString().split('\n');
+    const notStagedFiles = execSync('git diff --name-only --diff-filter=d').toString().split('\n');
     debug(`Retrieved the following files not staged: ${notStagedFiles}`);
     return notStagedFiles;
   }
 
   getStagedFiles(): string[] {
     debug(`getStagedFiles called`);
-    const stagedFiles = execSync('git diff --cached --name-only').toString().split('\n');
+    const stagedFiles = execSync('git diff --cached --name-only --diff-filter=d').toString().split('\n');
     debug(`Retrieved the following files staged: ${stagedFiles}`);
     return stagedFiles;
   }
 
   getPreviouslyCommitedFiles(nCommitsBeforeHead = 1): string[] {
     debug(`getPreviouslyCommitedFiles(${nCommitsBeforeHead}) called`);
-    const commitedFiles = execSync(`git diff-tree --no-commit-id --name-only -r HEAD~${nCommitsBeforeHead}`)
+    const commitedFiles = execSync(`git diff-tree --diff-filter=d --no-commit-id --name-only -r HEAD~${nCommitsBeforeHead}`)
       .toString()
       .split('\n');
     debug(`Retrieved the following files commited: ${commitedFiles}`);
@@ -58,7 +58,7 @@ export class GitToolkit {
 
   getFilesChangedBetweenRefs(from: string, to: string): string[] {
     debug(`getFilesChangedBetweenRefs(${from}, ${to}) called`);
-    const changedFiles = execSync(`git diff ${from} ${to} --name-only`).toString().split('\n');
+    const changedFiles = execSync(`git diff --diff-filter=d ${from} ${to} --name-only`).toString().split('\n');
 
     debug(`Retrieved the following files commited: ${changedFiles}`);
     return changedFiles;

--- a/packages/mookme/tests/cases/pre-commit-succeeds.sh
+++ b/packages/mookme/tests/cases/pre-commit-succeeds.sh
@@ -9,10 +9,13 @@ npm run build &> /dev/null
 cd $TESTS_DIR
 
 git init
+git commit --allow-empty -m "first commit"
 mkdir -p package1
+mkdir -p package1/.hooks
 mkdir -p parent1/package2
 mkdir -p parent1/package3
 mkdir -p parent1/package3/.hooks
+touch package1/tobedeleted.txt
 
 node $ROOT_FOLDER/dist/index.js init \
     --yes \
@@ -26,7 +29,13 @@ node $ROOT_FOLDER/dist/index.js init \
 chmod +x .hooks/partials/get-dir-name
 
 echo '{"steps": [{"name": "Hello world !", "command": "echo 'hello'"}]}' > .hooks/pre-commit.json
+echo '{"type": "txt", "steps": [{"name": "Ignore deleted files", "command": "cat {matchedFiles}"}]}' > package1/.hooks/pre-commit.json
 echo '{"steps": [{"name": "Hello world !", "command": "[  $(get-dir-name) = 'package3' ]"}]}' > parent1/package3/.hooks/pre-commit.json
 
 git add .
+node $ROOT_FOLDER/dist/index.js run -t pre-commit
+
+git commit -m "test: commit" --no-verify
+git rm package1/tobedeleted.txt
+
 node $ROOT_FOLDER/dist/index.js run -t pre-commit


### PR DESCRIPTION
… as we call out to `git diff` to get the list of files to process, we can add a `—diff-filter` argument that ignores deleted. This will allow us to skip running our hooks on files that no longer exist.

There was some confusion on the last PR as I used the wrong account.